### PR TITLE
fix(ripper): retry scan when drive reports DISC_OK but medium isn't data-readable (rip-start 422 on UNKNOWN disc)

### DIFF
--- a/services/ripper/arm_ripper/job_controller.py
+++ b/services/ripper/arm_ripper/job_controller.py
@@ -11,6 +11,7 @@ from arm_ripper.backend_client import BackendClient
 from arm_ripper.makemkv_key import refresh_makemkv_key
 from arm_ripper.rip import RipResult, rip_all
 from arm_ripper.rip.dispatcher import DEFAULT_MIN_LENGTH_SECONDS
+from arm_ripper.drive_poll import DriveState, read_drive_status
 from arm_ripper.scan import ScanError, scan as scan_disc
 from arm_ripper.source import is_iso_source
 from arm_ripper.ws_client import WSClient
@@ -37,6 +38,15 @@ RESOLUTION_WS_FIRST_WAIT_SECONDS = 5.0
 EJECT_RETRY_DELAYS = (0.0, 2.0, 5.0, 10.0)
 EJECT_PROCESS_TIMEOUT = 15.0
 RAW_ROOT = Path("/raw")
+# A freshly-settled disc can report DISC_OK via the CDROM_DRIVE_STATUS ioctl
+# before the medium is *data*-readable, so makemkvcon enumerates zero titles.
+# The disc IS present (per ioctl), so a zero-title scan there means "not ready
+# yet," not "genuinely empty" — retry, letting the drive finish spinning up /
+# the TOC become readable. Generous budget (a quick 1-2s retry would miss a slow
+# settle — the field report saw 4/4 discs fail); bounded so a genuinely
+# unreadable disc resolves to a clear give-up in ~26s.
+SCAN_NOT_READY_MAX_ATTEMPTS = 5
+SCAN_NOT_READY_BACKOFFS = (2.0, 4.0, 8.0, 12.0)  # between attempts 1→2, 2→3, 3→4, 4→5
 
 
 class JobController:
@@ -182,7 +192,7 @@ class JobController:
                 # protected discs with a stale key.
                 await refresh_makemkv_key(key=await self._configured_makemkv_key())
                 try:
-                    scan_result = await scan_disc(device_path)
+                    scan_result = await self._scan_with_ready_retry(device_path)
                 except ScanError as e:
                     logger.error("scan failed device=%s err=%s", device_path, e)
                     return
@@ -227,6 +237,64 @@ class JobController:
             finally:
                 self._active_task = None
                 self._active_job_id = None
+
+    async def _scan_with_ready_retry(self, device_path: str) -> ScanResult:
+        """Scan the disc, retrying when a DISC_OK drive yields zero titles.
+
+        A `DISC_OK` drive that scans to zero titles is almost certainly not
+        data-ready yet (the medium reports present via ioctl before the first
+        SCSI read succeeds). Retry with backoff to wait out the settle. If the
+        drive leaves DISC_OK (tray opened / disc pulled), stop. On exhaustion,
+        return the last (empty) result — the caller handles the give-up.
+        """
+        last: ScanResult | None = None
+        for attempt in range(1, SCAN_NOT_READY_MAX_ATTEMPTS + 1):
+            result = await scan_disc(device_path)
+            last = result
+            if result.titles:
+                return result
+
+            state = read_drive_status(device_path)
+            if state != DriveState.DISC_OK:
+                logger.info(
+                    "scan: 0 titles and drive no longer DISC_OK (state=%s) device=%s — stopping",
+                    state.name,
+                    device_path,
+                )
+                return result
+
+            if attempt < SCAN_NOT_READY_MAX_ATTEMPTS:
+                backoff = SCAN_NOT_READY_BACKOFFS[attempt - 1]
+                logger.warning(
+                    "scan returned 0 titles while drive=DISC_OK (data not ready?) "
+                    "device=%s titles=0 retry=%d/%d backoff=%.0fs",
+                    device_path,
+                    attempt,
+                    SCAN_NOT_READY_MAX_ATTEMPTS,
+                    backoff,
+                )
+                await asyncio.sleep(backoff)
+                # Re-check status after the sleep — disc may have been pulled
+                # while we were waiting; stop before wasting another scan probe.
+                post_sleep_state = read_drive_status(device_path)
+                if post_sleep_state != DriveState.DISC_OK:
+                    logger.info(
+                        "scan: drive left DISC_OK during backoff (state=%s) device=%s — stopping",
+                        post_sleep_state.name,
+                        device_path,
+                    )
+                    assert last is not None
+                    return last
+
+        logger.error(
+            "DISC_UNREADABLE_AFTER_RETRIES device=%s drive_state=DISC_OK attempts=%d — "
+            "disc present per ioctl but no readable titles after retries; check disc/drive "
+            "readiness (dirty/damaged disc, drive spin-up, or container device passthrough)",
+            device_path,
+            SCAN_NOT_READY_MAX_ATTEMPTS,
+        )
+        assert last is not None
+        return last
 
     async def _identify_with_retry(
         self,

--- a/services/ripper/arm_ripper/job_controller.py
+++ b/services/ripper/arm_ripper/job_controller.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import logging
 import shutil
 from pathlib import Path
@@ -595,7 +596,8 @@ class JobController:
         try:
             _, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=EJECT_PROCESS_TIMEOUT)
         except asyncio.TimeoutError:
-            proc.kill()
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
             await proc.wait()
             if log_failure:
                 logger.warning("%s timed out", argv[0])

--- a/services/ripper/arm_ripper/job_controller.py
+++ b/services/ripper/arm_ripper/job_controller.py
@@ -246,6 +246,11 @@ class JobController:
         SCSI read succeeds). Retry with backoff to wait out the settle. If the
         drive leaves DISC_OK (tray opened / disc pulled), stop. On exhaustion,
         return the last (empty) result — the caller handles the give-up.
+
+        Note: `read_drive_status` (os.open + ioctl) may raise OSError if the
+        device node vanishes mid-retry (USB autosuspend / passthrough teardown);
+        that propagates to the pipeline task boundary by design — the task ends
+        and the drive poller re-arms on the next disc-insert event.
         """
         last: ScanResult | None = None
         for attempt in range(1, SCAN_NOT_READY_MAX_ATTEMPTS + 1):
@@ -284,7 +289,7 @@ class JobController:
                         device_path,
                     )
                     assert last is not None
-                    return last
+                    return result
 
         logger.error(
             "DISC_UNREADABLE_AFTER_RETRIES device=%s drive_state=DISC_OK attempts=%d — "

--- a/services/ripper/tests/test_job_controller.py
+++ b/services/ripper/tests/test_job_controller.py
@@ -467,6 +467,23 @@ async def test_scan_retry_stops_when_disc_pulled(monkeypatch):
     assert calls["n"] == 1
 
 
+async def test_scan_retry_stops_pre_sleep_when_disc_absent(monkeypatch):
+    """Drive reports non-DISC_OK on the first status check (pre-sleep): stop immediately, no sleep."""
+    sleep_calls = {"n": 0}
+
+    async def _count_sleep(_):
+        sleep_calls["n"] += 1
+
+    monkeypatch.setattr(jc_module.asyncio, "sleep", _count_sleep)
+    monkeypatch.setattr(jc_module, "scan_disc", lambda _p: _async_return(_empty_scan()))
+    monkeypatch.setattr(jc_module, "read_drive_status", lambda _p: DriveState.NO_DISC)
+
+    controller = JobController(FakeClient(), "drv_test")
+    out = await controller._scan_with_ready_retry("/dev/sr0")
+    assert not out.titles
+    assert sleep_calls["n"] == 0  # exited before the backoff block — no sleep
+
+
 async def test_scan_retry_no_retry_on_first_success(monkeypatch):
     calls = {"n": 0, "status": 0}
 

--- a/services/ripper/tests/test_job_controller.py
+++ b/services/ripper/tests/test_job_controller.py
@@ -513,3 +513,26 @@ async def test_scan_retry_propagates_scanerror(monkeypatch):
     controller = JobController(FakeClient(), "drv_test")
     with pytest.raises(jc_module.ScanError):
         await controller._scan_with_ready_retry("/dev/sr0")
+
+
+async def test_run_command_kill_survives_process_lookup_error(monkeypatch):
+    class _DeadProc:
+        returncode = None
+
+        async def communicate(self):
+            raise asyncio.TimeoutError
+
+        def kill(self):
+            raise ProcessLookupError  # child already exited
+
+        async def wait(self):
+            return None
+
+    async def _fake_exec(*_a, **_k):
+        return _DeadProc()
+
+    monkeypatch.setattr(jc_module.asyncio, "create_subprocess_exec", _fake_exec)
+
+    rc, msg = await JobController._run_command("eject", "-sv", "/dev/sr0", log_failure=False)
+    assert rc is None
+    assert msg == "timeout"

--- a/services/ripper/tests/test_job_controller.py
+++ b/services/ripper/tests/test_job_controller.py
@@ -14,9 +14,11 @@ from arm_common.schemas import (
     RipperConfigView,
     RipStartResponse,
     ScanResult,
+    ScanTitle,
     TrackView,
     WSEnvelope,
 )
+from arm_ripper.drive_poll import DriveState
 from arm_ripper.job_controller import JobController
 
 
@@ -126,7 +128,11 @@ def stub_eject(monkeypatch):
 @pytest.fixture
 def stub_scan(monkeypatch):
     async def _scan(_device_path: str) -> ScanResult:
-        return ScanResult(disc_type=DiscType.DVD, volume_label="TEST")
+        return ScanResult(
+            disc_type=DiscType.DVD,
+            volume_label="TEST",
+            titles=[ScanTitle(index=0, duration_seconds=3600)],
+        )
 
     monkeypatch.setattr(jc_module, "scan_disc", _scan)
 
@@ -383,3 +389,110 @@ async def test_rip_start_5xx_keeps_retrying(monkeypatch, stub_scan, stub_eject):
 
     assert call_count == 3
     assert client.rip_complete_calls == ["job_test"]
+
+
+# ---------------------------------------------------------------------------
+# _scan_with_ready_retry — DISC_OK + zero-title race
+# ---------------------------------------------------------------------------
+
+
+async def _noop_async(*_a, **_k):
+    return None
+
+
+def _async_return(value):
+    async def _coro(*_a, **_k):
+        return value
+
+    return _coro()
+
+
+def _titled_scan() -> ScanResult:
+    return ScanResult(
+        disc_type=DiscType.DVD,
+        volume_label="MOVIE",
+        titles=[ScanTitle(index=0, duration_seconds=3600)],
+    )
+
+
+def _empty_scan() -> ScanResult:
+    return ScanResult(disc_type=DiscType.UNKNOWN, volume_label=None, titles=[])
+
+
+async def test_scan_retry_recovers_transient_not_ready(monkeypatch):
+    monkeypatch.setattr(jc_module.asyncio, "sleep", _noop_async)
+    results = deque([_empty_scan(), _titled_scan()])
+    calls = {"n": 0}
+
+    async def _scan(device_path):
+        calls["n"] += 1
+        return results.popleft()
+
+    monkeypatch.setattr(jc_module, "scan_disc", _scan)
+    monkeypatch.setattr(jc_module, "read_drive_status", lambda _p: DriveState.DISC_OK)
+
+    controller = JobController(FakeClient(), "drv_test")
+    out = await controller._scan_with_ready_retry("/dev/sr0")
+    assert out.titles
+    assert calls["n"] == 2
+
+
+async def test_scan_retry_exhausts_and_logs_marker(monkeypatch, caplog):
+    monkeypatch.setattr(jc_module.asyncio, "sleep", _noop_async)
+    monkeypatch.setattr(jc_module, "scan_disc", lambda _p: _async_return(_empty_scan()))
+    monkeypatch.setattr(jc_module, "read_drive_status", lambda _p: DriveState.DISC_OK)
+
+    controller = JobController(FakeClient(), "drv_test")
+    with caplog.at_level("ERROR"):
+        out = await controller._scan_with_ready_retry("/dev/sr0")
+    assert not out.titles
+    assert "DISC_UNREADABLE_AFTER_RETRIES" in caplog.text
+
+
+async def test_scan_retry_stops_when_disc_pulled(monkeypatch):
+    monkeypatch.setattr(jc_module.asyncio, "sleep", _noop_async)
+    calls = {"n": 0}
+
+    async def _scan(device_path):
+        calls["n"] += 1
+        return _empty_scan()
+
+    states = deque([DriveState.DISC_OK, DriveState.NO_DISC])
+    monkeypatch.setattr(jc_module, "scan_disc", _scan)
+    monkeypatch.setattr(jc_module, "read_drive_status", lambda _p: states.popleft())
+
+    controller = JobController(FakeClient(), "drv_test")
+    out = await controller._scan_with_ready_retry("/dev/sr0")
+    assert not out.titles
+    assert calls["n"] == 1
+
+
+async def test_scan_retry_no_retry_on_first_success(monkeypatch):
+    calls = {"n": 0, "status": 0}
+
+    async def _scan(device_path):
+        calls["n"] += 1
+        return _titled_scan()
+
+    def _status(_p):
+        calls["status"] += 1
+        return DriveState.DISC_OK
+
+    monkeypatch.setattr(jc_module, "scan_disc", _scan)
+    monkeypatch.setattr(jc_module, "read_drive_status", _status)
+
+    controller = JobController(FakeClient(), "drv_test")
+    out = await controller._scan_with_ready_retry("/dev/sr0")
+    assert out.titles
+    assert calls["n"] == 1
+    assert calls["status"] == 0
+
+
+async def test_scan_retry_propagates_scanerror(monkeypatch):
+    async def _scan(device_path):
+        raise jc_module.ScanError("makemkvcon rc=1")
+
+    monkeypatch.setattr(jc_module, "scan_disc", _scan)
+    controller = JobController(FakeClient(), "drv_test")
+    with pytest.raises(jc_module.ScanError):
+        await controller._scan_with_ready_retry("/dev/sr0")


### PR DESCRIPTION
## Summary

Fixes a v3.0.0-rc2 field bug where a freshly-inserted disc dead-ends at a cryptic rip-start **422** ("abandon job manually"). Root-caused from full ripper logs (4 consecutive different discs, all failing identically).

**Root cause — a scan-time `DISC_OK`-but-not-data-readable race:** the drive's `CDROM_DRIVE_STATUS` ioctl reports `DISC_OK`, the InsertDetector fires the scan, but the actual SCSI **data read** (makemkvcon `info`, pydvdid, discid) gets `No medium found` / `cannot read TOC` → `makemkvcon` exits 0 with **zero titles** → `scan_disc` returns an empty `ScanResult(disc_type=UNKNOWN)` → identify parks `awaiting_user_id` → operator resolves a title → **rip-start 422** (`no default rip preset for disc_type=unknown` / `track selection produced zero tracks`). The MakeMKV key is fine in every case (key refresh succeeds, no 5021/5052/5055) — the medium simply isn't data-readable yet when the scan fires.

## The fix (ripper-side only)

- **`JobController._scan_with_ready_retry`**: when `scan_disc` yields **zero titles while the drive still reports `DISC_OK`**, retry the scan with bounded escalating backoff (5 attempts, 2/4/8/12s, ~26s total) to wait out the spin-up / TOC-readable settle. The disc IS present per ioctl, so a zero-title scan there means "not data-ready yet," not "genuinely empty."
  - Transient settle → recovers (retry finds titles, proceeds normally).
  - Disc pulled mid-retry (drive leaves `DISC_OK`, checked pre- and post-backoff) → stops early.
  - Persistent unreadable (retries exhaust) → gives up with a distinctive, greppable **`DISC_UNREADABLE_AFTER_RETRIES`** ERROR marker + per-attempt WARNING lines, so the state is trivially identifiable in a future field report.
- **`proc.kill()` guard**: the eject-path `_run_command` timeout-kill is wrapped in `contextlib.suppress(ProcessLookupError)` so killing an already-exited child doesn't raise the noisy "Task exception was never retrieved" (the field report's Symptom 3).

`scan_disc` raising `ScanError` (hard failures like MSG:5021) propagates unchanged — only the *successful-but-empty* scan is retried.

## Not in scope (deliberate)

- **Not** re-adding the removed `verify_read` mode — its target race (drive idling *between* per-title `makemkvcon` calls) genuinely vanished with the single-invocation `mkv all` rip; the uncovered gap is *scan-time*, fixed here by retrying the scan.
- No new `JobStatus` / drive-media "unreadable" contract — log-only on exhaustion (the retry fixes the real, transient case).
- The same `proc.kill()` idiom exists at 9 other ripper sites (`scan/makemkv.py`, `rip/makemkv_rip.py`, etc.) — guarded here only at the cited eject path; broader guard is a noted follow-up.
- The reported WebSocket symptom is not reproduced (logs show a clean WS handshake).

## Test Plan

- [x] `uv run pytest` green — **896 passed** (6 scan-retry tests covering transient-recover / exhaust-marker / disc-pulled pre- & post-sleep / first-success-no-retry / ScanError-propagates, + the proc.kill `ProcessLookupError` guard test).
- [x] `ruff format --check` + `ruff check` clean (v0.15.11, matching CI).
- [x] Backoff timing is bounded (~26s) so a genuinely-unreadable disc resolves to the `DISC_UNREADABLE_AFTER_RETRIES` marker rather than hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)