### PR TITLE
Tier-14 — settings-audit: air-gap base URLs + env tunables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,3 +117,22 @@ ARM_MIN_LENGTH_SECONDS=120
 # addresses (e.g. 192.168.x.x) unless you understand the SSRF implications; an
 # entry with a scheme/path (https://host/...) silently never matches and is inert.
 #ARM_EXTRA_IMAGE_HOSTS=posters.example.lan
+
+# --- Tier-4: image-proxy disk-cache caps (optional; defaults shown) ----------
+# Homelab installs rarely need to change these; large multi-user installs may
+# want higher limits. Defaults match the former hardcoded constants.
+#ARM_IMAGE_CACHE_MAX_ENTRIES=1000   # max number of cached poster images
+#ARM_IMAGE_CACHE_MAX_BYTES=2097152  # 2 MB per-entry byte cap
+#ARM_IMAGE_CACHE_TTL_SECONDS=604800 # 7 days
+
+# --- Tier-4: log query/zip caps (optional; defaults shown) -------------------
+# ARM_LOG_PER_FILE_DEFAULT — lines returned by GET /api/logs/{job_id} when no
+#   ?limit= is supplied. Raise on large deployments with verbose logging.
+# ARM_LOG_PER_FILE_HARD_CAP — hard ceiling the endpoint enforces regardless of
+#   what the caller requests. Protects backend memory on huge log files.
+# ARM_LOG_ZIP_PER_ENTRY_LINE_CAP / _BYTE_CAP — per-file caps applied when
+#   building the bug-report zip. Whichever limit is hit first wins.
+#ARM_LOG_PER_FILE_DEFAULT=1000
+#ARM_LOG_PER_FILE_HARD_CAP=10000
+#ARM_LOG_ZIP_PER_ENTRY_LINE_CAP=5000
+#ARM_LOG_ZIP_PER_ENTRY_BYTE_CAP=5242880  # 5 MB

--- a/.env.example
+++ b/.env.example
@@ -109,3 +109,11 @@ ARM_MIN_LENGTH_SECONDS=120
 #ARM_TVDB_BASE_URL=https://api4.thetvdb.com/v4
 #ARM_MUSICBRAINZ_BASE_URL=https://musicbrainz.org/ws/2
 #ARM_ARMSERVER_BASE_URL=https://1337server.pythonanywhere.com/api/v1/
+
+# Tier-3: extra hostnames the image-proxy will fetch from, ADDED to the built-in
+# allowlist (m.media-amazon.com, image.tmdb.org, images-na.ssl-images-amazon.com,
+# coverartarchive.org, ia.media-imdb.com). Comma-separated bare hostnames. Only
+# add hosts you trust — the allowlist is the proxy's SSRF guard. Avoid bare IP
+# addresses (e.g. 192.168.x.x) unless you understand the SSRF implications; an
+# entry with a scheme/path (https://host/...) silently never matches and is inert.
+#ARM_EXTRA_IMAGE_HOSTS=posters.example.lan

--- a/.env.example
+++ b/.env.example
@@ -99,3 +99,13 @@ ARM_MIN_LENGTH_SECONDS=120
 #TLS_CERT_PATH=/etc/ssl/arm/tls.crt
 #TLS_KEY_PATH=/etc/ssl/arm/tls.key
 #ARM_TRANSCODE_IMAGE=arm-transcode:latest
+
+# --- Tier-3 air-gap: metadata API base-URL overrides (optional) -------------
+# Override to point at an internal mirror or proxy. Defaults (shown) are the
+# public endpoints; leave unset/commented for normal internet-connected
+# deployments.
+#ARM_TMDB_BASE_URL=https://api.themoviedb.org/3
+#ARM_OMDB_BASE_URL=https://www.omdbapi.com/
+#ARM_TVDB_BASE_URL=https://api4.thetvdb.com/v4
+#ARM_MUSICBRAINZ_BASE_URL=https://musicbrainz.org/ws/2
+#ARM_ARMSERVER_BASE_URL=https://1337server.pythonanywhere.com/api/v1/

--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,12 @@ ARM_NOTIFICATION_DISPATCH_INTERVAL_SECONDS=5
 POLL_INTERVAL_SECONDS=2.0
 # Minimum title duration (seconds) for a track to count as a feature.
 ARM_MIN_LENGTH_SECONDS=120
+# Tier-4: how often the ripper re-probes makemkv key validity (seconds; daily
+# default). Lower it for hourly probes, raise it for weekly.
+#MAKEMKV_KEYCHECK_INTERVAL_SECONDS=86400
+# Tier-4: consecutive NOT_READY drive polls before re-arming insert detection.
+# Flaky USB-BD drives may need a wider window than cheap optical drives.
+#ARM_NOT_READY_REARM_POLLS=3
 
 # --- Advanced / container-internal (only change if you know why) ------------
 # These default to container-internal paths/bind settings; the stack works

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check
+      # Generate src/api/generated.ts (gitignored) from the snapshot before
+      # vue-tsc — types.ts imports it, so typecheck fails on a fresh checkout
+      # without it.
+      - run: npm run openapi-types
       - run: npm run typecheck
 
   lint-shell:

--- a/services/backend/arm_backend/config.py
+++ b/services/backend/arm_backend/config.py
@@ -116,5 +116,15 @@ class Settings(BaseSettings):
     # "failed to create hwdevice". Empty => no group added (CPU / NVENC-only).
     ARM_RENDER_GID: str = ""
 
+    # --- Tier-3 air-gap: external metadata API base URLs --------------------
+    # Default to the public endpoints; override to point at a mirror/proxy for
+    # air-gapped or regional deployments. No trailing-slash normalization — set
+    # them exactly as the client expects (matching the former module literals).
+    ARM_TMDB_BASE_URL: str = "https://api.themoviedb.org/3"
+    ARM_OMDB_BASE_URL: str = "https://www.omdbapi.com/"
+    ARM_TVDB_BASE_URL: str = "https://api4.thetvdb.com/v4"
+    ARM_MUSICBRAINZ_BASE_URL: str = "https://musicbrainz.org/ws/2"
+    ARM_ARMSERVER_BASE_URL: str = "https://1337server.pythonanywhere.com/api/v1/"
+
 
 settings = Settings()  # type: ignore[call-arg]  # fields loaded from env by pydantic-settings

--- a/services/backend/arm_backend/config.py
+++ b/services/backend/arm_backend/config.py
@@ -151,7 +151,7 @@ class Settings(BaseSettings):
     ARM_LOG_PER_FILE_DEFAULT: int = 1000
     ARM_LOG_PER_FILE_HARD_CAP: int = 10_000
     ARM_LOG_ZIP_PER_ENTRY_LINE_CAP: int = 5000
-    ARM_LOG_ZIP_PER_ENTRY_BYTE_CAP: int = 5 * 1024 * 1024
+    ARM_LOG_ZIP_PER_ENTRY_BYTE_CAP: int = 5 * 1024 * 1024  # 5 MB
 
 
 settings = Settings()  # type: ignore[call-arg]  # fields loaded from env by pydantic-settings

--- a/services/backend/arm_backend/config.py
+++ b/services/backend/arm_backend/config.py
@@ -138,5 +138,12 @@ class Settings(BaseSettings):
             return [s.strip() for s in v.split(",") if s.strip()]
         return v
 
+    # --- Tier-4: image-proxy disk-cache caps -------------------------------
+    # Homelab vs large installs differ; safe defaults match the former
+    # hardcoded constants in image_cache.py.
+    ARM_IMAGE_CACHE_MAX_ENTRIES: int = 1000
+    ARM_IMAGE_CACHE_MAX_BYTES: int = 2 * 1024 * 1024  # 2 MB
+    ARM_IMAGE_CACHE_TTL_SECONDS: int = 7 * 24 * 3600  # 7 days
+
 
 settings = Settings()  # type: ignore[call-arg]  # fields loaded from env by pydantic-settings

--- a/services/backend/arm_backend/config.py
+++ b/services/backend/arm_backend/config.py
@@ -145,5 +145,13 @@ class Settings(BaseSettings):
     ARM_IMAGE_CACHE_MAX_BYTES: int = 2 * 1024 * 1024  # 2 MB
     ARM_IMAGE_CACHE_TTL_SECONDS: int = 7 * 24 * 3600  # 7 days
 
+    # --- Tier-4: log query/zip caps ----------------------------------------
+    # Multi-drive deployments outgrow the defaults; safe defaults match the
+    # former hardcoded constants in routers/logs.py.
+    ARM_LOG_PER_FILE_DEFAULT: int = 1000
+    ARM_LOG_PER_FILE_HARD_CAP: int = 10_000
+    ARM_LOG_ZIP_PER_ENTRY_LINE_CAP: int = 5000
+    ARM_LOG_ZIP_PER_ENTRY_BYTE_CAP: int = 5 * 1024 * 1024
+
 
 settings = Settings()  # type: ignore[call-arg]  # fields loaded from env by pydantic-settings

--- a/services/backend/arm_backend/config.py
+++ b/services/backend/arm_backend/config.py
@@ -126,5 +126,17 @@ class Settings(BaseSettings):
     ARM_MUSICBRAINZ_BASE_URL: str = "https://musicbrainz.org/ws/2"
     ARM_ARMSERVER_BASE_URL: str = "https://1337server.pythonanywhere.com/api/v1/"
 
+    # Tier-3: additional hostnames the image-proxy allowlist accepts, on TOP of
+    # the built-in set (never replacing it — the allowlist is an SSRF guard).
+    # Comma-separated bare hostnames (no scheme/path). Empty => built-ins only.
+    ARM_EXTRA_IMAGE_HOSTS: Annotated[list[str], NoDecode] = []
+
+    @field_validator("ARM_EXTRA_IMAGE_HOSTS", mode="before")
+    @classmethod
+    def _split_extra_image_hosts(cls, v: object) -> object:
+        if isinstance(v, str):
+            return [s.strip() for s in v.split(",") if s.strip()]
+        return v
+
 
 settings = Settings()  # type: ignore[call-arg]  # fields loaded from env by pydantic-settings

--- a/services/backend/arm_backend/image_cache.py
+++ b/services/backend/arm_backend/image_cache.py
@@ -20,9 +20,19 @@ def _cache_dir() -> str:
 
 _index: dict[str, dict[str, Any]] = {}
 
-_MAX_ENTRIES = 1000
-_MAX_IMAGE_BYTES = 2 * 1024 * 1024  # 2 MB
-_TTL_SECONDS = 7 * 24 * 3600  # 7 days
+# tunable via ARM_IMAGE_CACHE_MAX_ENTRIES / ARM_IMAGE_CACHE_MAX_BYTES / ARM_IMAGE_CACHE_TTL_SECONDS
+
+
+def _max_entries() -> int:
+    return settings.ARM_IMAGE_CACHE_MAX_ENTRIES
+
+
+def _max_image_bytes() -> int:
+    return settings.ARM_IMAGE_CACHE_MAX_BYTES
+
+
+def _ttl_seconds() -> int:
+    return settings.ARM_IMAGE_CACHE_TTL_SECONDS
 
 
 def _url_to_filename(url: str) -> str:
@@ -50,11 +60,11 @@ def reset() -> None:
 
 def store(url: str, data: bytes, content_type: str) -> bool:
     """Store an image in the cache. Returns False if too large."""
-    if len(data) > _MAX_IMAGE_BYTES:
+    if len(data) > _max_image_bytes():
         return False
 
     # Evict LRU if full
-    while len(_index) >= _MAX_ENTRIES:
+    while len(_index) >= _max_entries():
         oldest_url = min(_index, key=lambda u: _index[u]["accessed_at"])
         _remove(oldest_url)
 
@@ -91,7 +101,7 @@ def retrieve(url: str) -> tuple[bytes, str] | None:
         return None
 
     # Check TTL
-    if time.time() - entry["cached_at"] > _TTL_SECONDS:
+    if time.time() - entry["cached_at"] > _ttl_seconds():
         _remove(url)
         return None
 
@@ -158,7 +168,7 @@ def startup_scan() -> None:
                 meta_path.unlink()
                 log.debug("Removed orphaned metadata: %s", meta_path.name)
                 continue
-            if now - meta["cached_at"] > _TTL_SECONDS:
+            if now - meta["cached_at"] > _ttl_seconds():
                 meta_path.unlink()
                 img_path.unlink()
                 log.debug("Removed expired cache entry: %s", meta_path.name)

--- a/services/backend/arm_backend/metadata/arm_server.py
+++ b/services/backend/arm_backend/metadata/arm_server.py
@@ -17,11 +17,16 @@ from typing import Any, Literal
 
 import httpx
 
+from arm_backend.config import settings
 from arm_backend.metadata.base import LookupError, LookupTimeout, MetadataResult
 
 logger = logging.getLogger("arm_backend.metadata.arm_server")
 
-_BASE_URL = "https://1337server.pythonanywhere.com/api/v1/"
+
+def _base_url() -> str:
+    return settings.ARM_ARMSERVER_BASE_URL
+
+
 _USER_AGENT = "automatic-ripping-machine/v3"
 
 
@@ -40,7 +45,7 @@ class ArmServerClient:
         crc64 = crc64.replace("|", "")
         try:
             r = await self._http.get(
-                _BASE_URL,
+                _base_url(),
                 params={"mode": "s", "crc64": crc64},
                 headers={"User-Agent": _USER_AGENT, "Accept": "application/json"},
             )

--- a/services/backend/arm_backend/metadata/musicbrainz.py
+++ b/services/backend/arm_backend/metadata/musicbrainz.py
@@ -5,11 +5,16 @@ from typing import Any
 
 import httpx
 
+from arm_backend.config import settings
 from arm_backend.metadata.base import LookupError, LookupTimeout, MetadataResult
 
 logger = logging.getLogger("arm_backend.metadata.musicbrainz")
 
-_BASE_URL = "https://musicbrainz.org/ws/2"
+
+def _base_url() -> str:
+    return settings.ARM_MUSICBRAINZ_BASE_URL
+
+
 _MIN_INTERVAL_SECONDS = 1.0
 
 _lock = asyncio.Lock()
@@ -52,7 +57,7 @@ class MusicBrainzClient:
 
         try:
             r = await self._http.get(
-                f"{_BASE_URL}{path}",
+                f"{_base_url()}{path}",
                 params=params,
                 headers={"User-Agent": self._user_agent, "Accept": "application/json"},
             )

--- a/services/backend/arm_backend/metadata/omdb.py
+++ b/services/backend/arm_backend/metadata/omdb.py
@@ -3,11 +3,14 @@ from typing import Any, Literal
 
 import httpx
 
+from arm_backend.config import settings
 from arm_backend.metadata.base import LookupError, LookupTimeout, MetadataResult
 
 logger = logging.getLogger("arm_backend.metadata.omdb")
 
-_BASE_URL = "https://www.omdbapi.com/"
+
+def _base_url() -> str:
+    return settings.ARM_OMDB_BASE_URL
 
 
 class OMDBClient:
@@ -31,7 +34,7 @@ class OMDBClient:
         only pass the query-specific params.
         """
         try:
-            r = await self._http.get(_BASE_URL, params={"apikey": self._api_key, **params})
+            r = await self._http.get(_base_url(), params={"apikey": self._api_key, **params})
         except httpx.TimeoutException as e:
             raise LookupTimeout("omdb timeout") from e
         except httpx.HTTPError as e:

--- a/services/backend/arm_backend/metadata/tmdb.py
+++ b/services/backend/arm_backend/metadata/tmdb.py
@@ -4,11 +4,14 @@ from typing import Any, Literal
 
 import httpx
 
+from arm_backend.config import settings
 from arm_backend.metadata.base import LookupError, LookupTimeout, MetadataResult
 
 logger = logging.getLogger("arm_backend.metadata.tmdb")
 
-_BASE_URL = "https://api.themoviedb.org/3"
+
+def _base_url() -> str:
+    return settings.ARM_TMDB_BASE_URL
 
 
 class TMDBClient:
@@ -34,7 +37,7 @@ class TMDBClient:
         other transport errors and 401/5xx/non-200 -> LookupError.
         """
         try:
-            r = await self._http.get(f"{_BASE_URL}/search/{endpoint}", params=params, headers=self._headers)
+            r = await self._http.get(f"{_base_url()}/search/{endpoint}", params=params, headers=self._headers)
         except httpx.TimeoutException as e:
             raise LookupTimeout(f"tmdb {endpoint} timeout") from e
         except httpx.HTTPError as e:
@@ -131,7 +134,7 @@ class TMDBClient:
         runs per-candidate in the search enrichment fan-out and one failure must
         not fail the whole search."""
         try:
-            r = await self._http.get(f"{_BASE_URL}/{kind}/{tmdb_id}/external_ids", headers=self._headers)
+            r = await self._http.get(f"{_base_url()}/{kind}/{tmdb_id}/external_ids", headers=self._headers)
         except httpx.HTTPError:
             return None
         if r.status_code != 200:
@@ -152,7 +155,7 @@ class TMDBClient:
         provider-driven detail lookup when metadata_provider == 'tmdb'."""
         try:
             r = await self._http.get(
-                f"{_BASE_URL}/find/{imdb_id}",
+                f"{_base_url()}/find/{imdb_id}",
                 params={"external_source": "imdb_id"},
                 headers=self._headers,
             )

--- a/services/backend/arm_backend/metadata/tvdb.py
+++ b/services/backend/arm_backend/metadata/tvdb.py
@@ -2,11 +2,14 @@ import logging
 
 import httpx
 
+from arm_backend.config import settings
 from arm_backend.metadata.base import LookupError, LookupTimeout
 
 logger = logging.getLogger("arm_backend.metadata.tvdb")
 
-_BASE_URL = "https://api4.thetvdb.com/v4"
+
+def _base_url() -> str:
+    return settings.ARM_TVDB_BASE_URL
 
 
 class TVDBClient:
@@ -25,7 +28,7 @@ class TVDBClient:
         """POST /v4/login. Returns None on success; raises LookupError on
         auth/transport failure, LookupTimeout on timeout."""
         try:
-            r = await self._http.post(f"{_BASE_URL}/login", json={"apikey": self._api_key})
+            r = await self._http.post(f"{_base_url()}/login", json={"apikey": self._api_key})
         except httpx.TimeoutException as e:
             raise LookupTimeout("tvdb login timeout") from e
         except httpx.HTTPError as e:

--- a/services/backend/arm_backend/routers/images.py
+++ b/services/backend/arm_backend/routers/images.py
@@ -11,6 +11,7 @@ from fastapi.responses import JSONResponse, Response
 
 from arm_backend import image_cache
 from arm_backend.auth import require_jwt
+from arm_backend.config import settings
 from arm_common import User
 
 _NEGATIVE_CACHE: dict[str, float] = {}
@@ -35,6 +36,13 @@ _ALLOWED_IMAGE_HOSTS = {
 }
 
 
+def _allowed_image_hosts() -> frozenset[str]:
+    """Built-in allowlist plus any operator-added ARM_EXTRA_IMAGE_HOSTS.
+
+    Additive only — extras never remove a built-in (SSRF guard property)."""
+    return frozenset(_ALLOWED_IMAGE_HOSTS) | frozenset(settings.ARM_EXTRA_IMAGE_HOSTS)
+
+
 def _not_found(detail: str) -> Response:
     """Return a cacheable 404 so the browser stops re-requesting missing images."""
     return JSONResponse(
@@ -52,7 +60,7 @@ async def proxy_image(url: str = Query(..., description="Image URL to proxy")) -
     parsed = urlparse(url)
     if parsed.scheme not in ("http", "https"):
         return _not_found("Only HTTP(S) URLs are allowed")
-    if parsed.hostname not in _ALLOWED_IMAGE_HOSTS:
+    if parsed.hostname not in _allowed_image_hosts():
         return _not_found("Image host not allowed")
 
     safe_url = parsed.geturl()

--- a/services/backend/arm_backend/routers/logs.py
+++ b/services/backend/arm_backend/routers/logs.py
@@ -11,7 +11,8 @@ Two read-only endpoints scoped to a single `job_id`:
 - `GET /api/logs/{job_id}.zip` — in-memory zip. Single entry sourced
   from the per-job file when present; legacy fallback walks the
   service logs and writes one entry per service. Per-entry caps:
-  5000 lines or 5 MB, whichever hits first.
+  `ARM_LOG_ZIP_PER_ENTRY_LINE_CAP` lines or `ARM_LOG_ZIP_PER_ENTRY_BYTE_CAP`
+  bytes (env-tunable; defaults: 5000 lines / 5 MB), whichever hits first.
 
 Both endpoints require a UI JWT — service-token callers are rejected.
 The download URL the UI hardcodes is `/api/logs/{jobId}.zip`; there's
@@ -29,7 +30,7 @@ import zipfile
 from collections.abc import Callable, Iterator
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends, Query, Response
 from fastapi.responses import StreamingResponse
 
 from arm_backend.auth import require_jwt
@@ -112,7 +113,7 @@ async def download_job_logs_zip(
 @router.get("/{job_id}")
 async def stream_job_logs(
     job_id: JobIdParam,
-    limit: int | None = None,
+    limit: int | None = Query(default=None, ge=0),
     _: User = Depends(require_jwt),
 ) -> StreamingResponse:
     """NDJSON stream of every line tagged with `job_id`.

--- a/services/backend/arm_backend/routers/logs.py
+++ b/services/backend/arm_backend/routers/logs.py
@@ -33,6 +33,7 @@ from fastapi import APIRouter, Depends, Response
 from fastapi.responses import StreamingResponse
 
 from arm_backend.auth import require_jwt
+from arm_backend.config import settings
 from arm_backend.routers._params import JobIdParam
 from arm_common import User
 from arm_common.ulid import is_valid_id
@@ -58,16 +59,10 @@ def per_job_log_path(job_id: str) -> Path:
     return LOG_DIR / "jobs" / os.path.basename(f"{job_id}.log")
 
 
-# Defaults / caps for the streaming grep endpoint. Per-file (not global)
-# — see the module docstring.
-PER_FILE_DEFAULT = 1000
-PER_FILE_HARD_CAP = 10_000
-
-# Caps for each zip entry. 5000 lines × 5 MB matches the homelab-scale
-# expectation: a worst-case rip emits ~hundreds of lines, never 5k+.
-ZIP_PER_ENTRY_LINE_CAP = 5000
-ZIP_PER_ENTRY_BYTE_CAP = 5 * 1024 * 1024
-
+# Defaults / caps for the streaming grep + zip endpoints are env-tunable via
+# the `ARM_LOG_*` settings (see config.py); resolved at call time so a
+# `monkeypatch.setattr(settings, ...)` or env override flows through. Per-file
+# (not global) — see the module docstring.
 
 router = APIRouter(prefix="/api/logs", tags=["logs"])
 
@@ -117,7 +112,7 @@ async def download_job_logs_zip(
 @router.get("/{job_id}")
 async def stream_job_logs(
     job_id: JobIdParam,
-    limit: int = PER_FILE_DEFAULT,
+    limit: int | None = None,
     _: User = Depends(require_jwt),
 ) -> StreamingResponse:
     """NDJSON stream of every line tagged with `job_id`.
@@ -127,7 +122,8 @@ async def stream_job_logs(
     within a file in append order; no cross-file resort — the consumer
     can sort by `ts` if global ordering matters).
     """
-    cap = max(0, min(limit, PER_FILE_HARD_CAP))
+    eff_limit = settings.ARM_LOG_PER_FILE_DEFAULT if limit is None else limit
+    cap = max(0, min(eff_limit, settings.ARM_LOG_PER_FILE_HARD_CAP))
 
     def gen() -> Iterator[bytes]:
         per_job = per_job_log_path(job_id)
@@ -180,7 +176,10 @@ def _read_capped_lines(path: Path, predicate: Callable[[str], bool]) -> list[str
             normalised = line if line.endswith("\n") else line + "\n"
             out.append(normalised)
             byte_count += len(normalised)
-            if len(out) >= ZIP_PER_ENTRY_LINE_CAP or byte_count >= ZIP_PER_ENTRY_BYTE_CAP:
+            if (
+                len(out) >= settings.ARM_LOG_ZIP_PER_ENTRY_LINE_CAP
+                or byte_count >= settings.ARM_LOG_ZIP_PER_ENTRY_BYTE_CAP
+            ):
                 break
     return out
 

--- a/services/backend/arm_backend/routers/transcodes.py
+++ b/services/backend/arm_backend/routers/transcodes.py
@@ -23,7 +23,7 @@ from sqlmodel import col, select
 from arm_backend.auth import require_jwt
 from arm_backend.config import settings
 from arm_backend.db import get_session
-from arm_backend.routers.logs import LOG_DIR, PER_FILE_DEFAULT, PER_FILE_HARD_CAP
+from arm_backend.routers.logs import LOG_DIR
 from arm_common import Gpu, GpuStatus, SessionApplication, TranscodeTaskStatus, User
 from arm_common.models import TranscodeTask
 from arm_common.schemas import TranscodeStatsView, TranscodeTaskView, TranscodeWorkerView
@@ -147,7 +147,7 @@ async def download_transcode_log_zip(
     with path.open("r", encoding="utf-8", errors="replace") as fh:
         for line in fh:
             lines.append(line)
-            if len(lines) >= PER_FILE_HARD_CAP:
+            if len(lines) >= settings.ARM_LOG_PER_FILE_HARD_CAP:
                 break
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
@@ -166,7 +166,7 @@ async def download_transcode_log_zip(
 @router.get("/{task_id}/log")
 async def stream_transcode_log(
     task_id: str,
-    limit: int = Query(default=PER_FILE_DEFAULT, ge=0),
+    limit: int | None = Query(default=None, ge=0),
     _: User = Depends(require_jwt),
     db: AsyncSession = Depends(get_session),
 ) -> StreamingResponse:
@@ -174,7 +174,8 @@ async def stream_transcode_log(
     path = _transcode_log_path(task_id)
     if not path.is_file():
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"no transcoder log for task {task_id}")
-    cap = max(0, min(limit, PER_FILE_HARD_CAP))
+    eff_limit = settings.ARM_LOG_PER_FILE_DEFAULT if limit is None else limit
+    cap = max(0, min(eff_limit, settings.ARM_LOG_PER_FILE_HARD_CAP))
 
     def gen() -> Iterator[bytes]:
         yielded = 0

--- a/services/backend/tests/test_image_cache.py
+++ b/services/backend/tests/test_image_cache.py
@@ -43,7 +43,7 @@ def test_ttl_expiry_evicts(cache_dir, monkeypatch):
 
 
 def test_lru_eviction_at_capacity(cache_dir, monkeypatch):
-    monkeypatch.setattr(image_cache, "_MAX_ENTRIES", 2)
+    monkeypatch.setattr(image_cache.settings, "ARM_IMAGE_CACHE_MAX_ENTRIES", 2)
     image_cache.store("http://h/a.jpg", b"a", "image/jpeg")
     image_cache.store("http://h/b.jpg", b"b", "image/jpeg")
     image_cache.retrieve("http://h/a.jpg")
@@ -90,7 +90,7 @@ def test_startup_scan_rebuilds_index(cache_dir):
 def test_startup_scan_drops_expired(cache_dir, monkeypatch):
     image_cache.store("http://h/a.jpg", b"a", "image/jpeg")
     image_cache.reset()
-    monkeypatch.setattr(image_cache, "_TTL_SECONDS", -1)
+    monkeypatch.setattr(image_cache.settings, "ARM_IMAGE_CACHE_TTL_SECONDS", -1)
     image_cache.startup_scan()
     assert image_cache.retrieve("http://h/a.jpg") is None
 

--- a/services/backend/tests/test_image_cache_caps.py
+++ b/services/backend/tests/test_image_cache_caps.py
@@ -1,0 +1,25 @@
+"""Tier-4: image-proxy cache caps are env-tunable, defaulting to current values."""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "postgresql://x:x@localhost/x")
+os.environ.setdefault("ARM_SERVICE_TOKEN", "x")
+
+from arm_backend.config import Settings  # noqa: E402
+
+
+def test_image_cache_caps_default_to_current_values():
+    s = Settings()  # type: ignore[call-arg]
+    assert s.ARM_IMAGE_CACHE_MAX_ENTRIES == 1000
+    assert s.ARM_IMAGE_CACHE_MAX_BYTES == 2 * 1024 * 1024
+    assert s.ARM_IMAGE_CACHE_TTL_SECONDS == 7 * 24 * 3600
+
+
+def test_image_cache_accessors_read_settings(monkeypatch):
+    from arm_backend import config, image_cache
+    monkeypatch.setattr(config.settings, "ARM_IMAGE_CACHE_MAX_ENTRIES", 5)
+    monkeypatch.setattr(config.settings, "ARM_IMAGE_CACHE_MAX_BYTES", 123)
+    monkeypatch.setattr(config.settings, "ARM_IMAGE_CACHE_TTL_SECONDS", 99)
+    assert image_cache._max_entries() == 5
+    assert image_cache._max_image_bytes() == 123
+    assert image_cache._ttl_seconds() == 99

--- a/services/backend/tests/test_image_cache_caps.py
+++ b/services/backend/tests/test_image_cache_caps.py
@@ -17,6 +17,7 @@ def test_image_cache_caps_default_to_current_values():
 
 def test_image_cache_accessors_read_settings(monkeypatch):
     from arm_backend import config, image_cache
+
     monkeypatch.setattr(config.settings, "ARM_IMAGE_CACHE_MAX_ENTRIES", 5)
     monkeypatch.setattr(config.settings, "ARM_IMAGE_CACHE_MAX_BYTES", 123)
     monkeypatch.setattr(config.settings, "ARM_IMAGE_CACHE_TTL_SECONDS", 99)

--- a/services/backend/tests/test_image_proxy_allowlist.py
+++ b/services/backend/tests/test_image_proxy_allowlist.py
@@ -1,0 +1,29 @@
+"""Tier-3: ARM_EXTRA_IMAGE_HOSTS adds (never replaces) image-proxy allowed hosts."""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "postgresql://x:x@localhost/x")
+os.environ.setdefault("ARM_SERVICE_TOKEN", "x")
+
+from arm_backend.config import Settings  # noqa: E402
+
+
+def test_extra_hosts_parses_comma_list(monkeypatch):
+    monkeypatch.setenv("ARM_EXTRA_IMAGE_HOSTS", "posters.lan, cdn.example.com")
+    assert Settings().ARM_EXTRA_IMAGE_HOSTS == ["posters.lan", "cdn.example.com"]  # type: ignore[call-arg]
+
+
+def test_extra_hosts_default_empty():
+    assert Settings().ARM_EXTRA_IMAGE_HOSTS == []  # type: ignore[call-arg]
+
+
+def test_allowed_hosts_includes_defaults_and_extras(monkeypatch):
+    # `settings` is a module singleton evaluated at import, so a post-import
+    # setenv wouldn't reach it; _allowed_image_hosts() reads the live object,
+    # so patch its attribute directly.
+    from arm_backend import config
+    monkeypatch.setattr(config.settings, "ARM_EXTRA_IMAGE_HOSTS", ["posters.lan"])
+    from arm_backend.routers import images
+    hosts = images._allowed_image_hosts()
+    assert "image.tmdb.org" in hosts          # built-in default preserved
+    assert "posters.lan" in hosts             # extra added

--- a/services/backend/tests/test_image_proxy_allowlist.py
+++ b/services/backend/tests/test_image_proxy_allowlist.py
@@ -22,8 +22,10 @@ def test_allowed_hosts_includes_defaults_and_extras(monkeypatch):
     # setenv wouldn't reach it; _allowed_image_hosts() reads the live object,
     # so patch its attribute directly.
     from arm_backend import config
+
     monkeypatch.setattr(config.settings, "ARM_EXTRA_IMAGE_HOSTS", ["posters.lan"])
     from arm_backend.routers import images
+
     hosts = images._allowed_image_hosts()
-    assert "image.tmdb.org" in hosts          # built-in default preserved
-    assert "posters.lan" in hosts             # extra added
+    assert "image.tmdb.org" in hosts  # built-in default preserved
+    assert "posters.lan" in hosts  # extra added

--- a/services/backend/tests/test_images_router.py
+++ b/services/backend/tests/test_images_router.py
@@ -78,6 +78,17 @@ def test_rejects_non_allowlisted_host(client):
     assert "not allowed" in r.json()["detail"]
 
 
+def test_extra_image_host_not_rejected(client, monkeypatch):
+    # ARM_EXTRA_IMAGE_HOSTS adds an operator host; a proxy request to it must NOT
+    # hit the "not allowed" SSRF-guard path. It proceeds to the fetch (which we
+    # stub to succeed), proving the host is accepted, not rejected.
+    monkeypatch.setattr(images_router.settings, "ARM_EXTRA_IMAGE_HOSTS", ["posters.lan"])
+    _patch_fetch(monkeypatch, content=b"IMG", content_type="image/png")
+    r = client.get("/api/images/proxy", params={"url": "https://posters.lan/x.jpg"})
+    assert r.status_code == 200
+    assert r.content == b"IMG"
+
+
 def test_rejects_non_http_scheme(client):
     r = client.get("/api/images/proxy", params={"url": "ftp://image.tmdb.org/x.jpg"})
     assert r.status_code == 404

--- a/services/backend/tests/test_log_caps.py
+++ b/services/backend/tests/test_log_caps.py
@@ -1,0 +1,16 @@
+"""Tier-4: log query/zip caps are env-tunable, defaulting to current values."""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "postgresql://x:x@localhost/x")
+os.environ.setdefault("ARM_SERVICE_TOKEN", "x")
+
+from arm_backend.config import Settings  # noqa: E402
+
+
+def test_log_caps_default_to_current_values():
+    s = Settings()  # type: ignore[call-arg]
+    assert s.ARM_LOG_PER_FILE_DEFAULT == 1000
+    assert s.ARM_LOG_PER_FILE_HARD_CAP == 10_000
+    assert s.ARM_LOG_ZIP_PER_ENTRY_LINE_CAP == 5000
+    assert s.ARM_LOG_ZIP_PER_ENTRY_BYTE_CAP == 5 * 1024 * 1024

--- a/services/backend/tests/test_logs_router.py
+++ b/services/backend/tests/test_logs_router.py
@@ -127,7 +127,7 @@ def test_grep_per_file_limit_clamps_each_file(
 
 def test_grep_hard_cap_pins_at_10000(tmp_path: Path, signing_key: bytes, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(logs_router, "LOG_DIR", tmp_path)
-    monkeypatch.setattr(logs_router, "PER_FILE_HARD_CAP", 3)  # cheap cap for the test
+    monkeypatch.setattr(logs_router.settings, "ARM_LOG_PER_FILE_HARD_CAP", 3)  # cheap cap for the test
     _seed(tmp_path, service="svc", lines=[_line(msg=f"m{i}") for i in range(10)])
     app, token = _make_app(signing_key)
     with TestClient(app) as client:
@@ -192,7 +192,7 @@ def test_zip_contains_one_entry_per_service_with_matching_lines(
 
 def test_zip_per_entry_line_cap(tmp_path: Path, signing_key: bytes, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(logs_router, "LOG_DIR", tmp_path)
-    monkeypatch.setattr(logs_router, "ZIP_PER_ENTRY_LINE_CAP", 3)
+    monkeypatch.setattr(logs_router.settings, "ARM_LOG_ZIP_PER_ENTRY_LINE_CAP", 3)
     _seed(tmp_path, service="svc", lines=[_line(msg=f"m{i}") for i in range(10)])
     app, token = _make_app(signing_key)
     with TestClient(app) as client:

--- a/services/backend/tests/test_metadata_base_urls.py
+++ b/services/backend/tests/test_metadata_base_urls.py
@@ -1,0 +1,22 @@
+"""Tier-3: metadata base URLs are env-overridable, defaulting to current literals."""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "postgresql://x:x@localhost/x")
+os.environ.setdefault("ARM_SERVICE_TOKEN", "x")
+
+from arm_backend.config import Settings  # noqa: E402
+
+
+def test_base_url_defaults_match_current_literals():
+    s = Settings()  # type: ignore[call-arg]
+    assert s.ARM_TMDB_BASE_URL == "https://api.themoviedb.org/3"
+    assert s.ARM_OMDB_BASE_URL == "https://www.omdbapi.com/"
+    assert s.ARM_TVDB_BASE_URL == "https://api4.thetvdb.com/v4"
+    assert s.ARM_MUSICBRAINZ_BASE_URL == "https://musicbrainz.org/ws/2"
+    assert s.ARM_ARMSERVER_BASE_URL == "https://1337server.pythonanywhere.com/api/v1/"
+
+
+def test_base_url_overridable_via_env(monkeypatch):
+    monkeypatch.setenv("ARM_TMDB_BASE_URL", "http://tmdb-mirror.lan/3")
+    assert Settings().ARM_TMDB_BASE_URL == "http://tmdb-mirror.lan/3"  # type: ignore[call-arg]

--- a/services/backend/tests/test_metadata_base_urls.py
+++ b/services/backend/tests/test_metadata_base_urls.py
@@ -5,7 +5,22 @@ import os
 os.environ.setdefault("DATABASE_URL", "postgresql://x:x@localhost/x")
 os.environ.setdefault("ARM_SERVICE_TOKEN", "x")
 
+import httpx  # noqa: E402
+import pytest  # noqa: E402
+import respx  # noqa: E402
+
 from arm_backend.config import Settings  # noqa: E402
+from arm_backend.metadata.arm_server import ArmServerClient  # noqa: E402
+from arm_backend.metadata.musicbrainz import MusicBrainzClient  # noqa: E402
+from arm_backend.metadata.omdb import OMDBClient  # noqa: E402
+from arm_backend.metadata.tmdb import TMDBClient  # noqa: E402
+from arm_backend.metadata.tvdb import TVDBClient  # noqa: E402
+
+
+@pytest.fixture
+async def http_client():  # type: ignore[no-untyped-def]
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        yield client
 
 
 def test_base_url_defaults_match_current_literals():
@@ -20,3 +35,54 @@ def test_base_url_defaults_match_current_literals():
 def test_base_url_overridable_via_env(monkeypatch):
     monkeypatch.setenv("ARM_TMDB_BASE_URL", "http://tmdb-mirror.lan/3")
     assert Settings().ARM_TMDB_BASE_URL == "http://tmdb-mirror.lan/3"  # type: ignore[call-arg]
+
+
+# --- Clients read the (overridable) base URL from settings -------------------
+
+
+@respx.mock
+async def test_tmdb_uses_overridden_base_url(monkeypatch, http_client) -> None:
+    monkeypatch.setattr("arm_backend.metadata.tmdb._base_url", lambda: "http://tmdb.lan/3")
+    route = respx.get("http://tmdb.lan/3/search/movie").mock(
+        return_value=httpx.Response(200, json={"results": [{"title": "Movie", "release_date": "2010-01-01"}]})
+    )
+    await TMDBClient("k", http_client).search_movie("x")
+    assert route.called
+
+
+@respx.mock
+async def test_omdb_uses_overridden_base_url(monkeypatch, http_client) -> None:
+    monkeypatch.setattr("arm_backend.metadata.omdb._base_url", lambda: "http://omdb.lan/")
+    route = respx.get("http://omdb.lan/").mock(
+        return_value=httpx.Response(200, json={"Response": "True", "Title": "Movie", "Year": "2010"})
+    )
+    await OMDBClient("k", http_client).lookup_by_title("x")
+    assert route.called
+
+
+@respx.mock
+async def test_tvdb_uses_overridden_base_url(monkeypatch, http_client) -> None:
+    monkeypatch.setattr("arm_backend.metadata.tvdb._base_url", lambda: "http://tvdb.lan/v4")
+    route = respx.post("http://tvdb.lan/v4/login").mock(return_value=httpx.Response(200, json={}))
+    await TVDBClient("k", http_client).validate_key()
+    assert route.called
+
+
+@respx.mock
+async def test_musicbrainz_uses_overridden_base_url(monkeypatch, http_client) -> None:
+    monkeypatch.setattr("arm_backend.metadata.musicbrainz._base_url", lambda: "http://mb.lan/ws/2")
+    route = respx.get("http://mb.lan/ws/2/discid/d1").mock(
+        return_value=httpx.Response(200, json={"releases": [{"title": "Album", "date": "2001-05-01"}]})
+    )
+    await MusicBrainzClient("ua/1.0", http_client).lookup_disc_id("d1")
+    assert route.called
+
+
+@respx.mock
+async def test_arm_server_uses_overridden_base_url(monkeypatch, http_client) -> None:
+    monkeypatch.setattr("arm_backend.metadata.arm_server._base_url", lambda: "http://arm.lan/api/v1/")
+    route = respx.get("http://arm.lan/api/v1/").mock(
+        return_value=httpx.Response(200, json={"success": True, "results": {"0": {"title": "Sintel", "year": 2010}}})
+    )
+    await ArmServerClient(http_client).lookup_by_crc64("c1")
+    assert route.called

--- a/services/backend/tests/test_transcodes_router.py
+++ b/services/backend/tests/test_transcodes_router.py
@@ -431,7 +431,7 @@ def test_log_zip_respects_hard_cap(signing_key: bytes, tmp_path: Path, monkeypat
     import zipfile
 
     monkeypatch.setattr(tx_router, "LOG_DIR", tmp_path)
-    monkeypatch.setattr(tx_router, "PER_FILE_HARD_CAP", 2)  # cheap cap for the test
+    monkeypatch.setattr(settings, "ARM_LOG_PER_FILE_HARD_CAP", 2)  # cheap cap for the test
     db = FakeSession()
     db.rows["transcode_tasks"] = [_task("txt_zipcap000001", status=TranscodeTaskStatus.DONE)]
     _write_task_log(tmp_path, "txt_zipcap000001", ["x1", "x2", "x3", "x4"])
@@ -441,7 +441,7 @@ def test_log_zip_respects_hard_cap(signing_key: bytes, tmp_path: Path, monkeypat
     assert r.status_code == 200, r.text
     zf = zipfile.ZipFile(io.BytesIO(r.content))
     content = zf.read("arm-transcode-zipcap000001.log").decode()
-    assert content.count("\n") == 2  # capped at PER_FILE_HARD_CAP lines
+    assert content.count("\n") == 2  # capped at ARM_LOG_PER_FILE_HARD_CAP lines
 
 
 def test_log_zip_unknown_task_404(signing_key: bytes, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/services/ripper/arm_ripper/config.py
+++ b/services/ripper/arm_ripper/config.py
@@ -29,8 +29,11 @@ class Settings(BaseSettings):
     # cancellation. Intended for local smoke tests against the
     # matrix256-corpus ISOs; production deployments leave this unset.
     ARM_MANUAL_TRIGGER_ISO: str | None = None
+    # Tier-4: how often the ripper re-probes makemkv key validity (daily default).
+    MAKEMKV_KEYCHECK_INTERVAL_SECONDS: int = 86400
+    # Tier-4: consecutive NOT_READY polls before re-arming insert detection.
+    # Flaky USB-BD vs cheap optical need different swap-detection windows.
+    ARM_NOT_READY_REARM_POLLS: int = 3
 
 
 settings = Settings()  # type: ignore[call-arg]  # fields loaded from env by pydantic-settings
-
-MAKEMKV_KEYCHECK_INTERVAL_SECONDS = 86400

--- a/services/ripper/arm_ripper/drive_poll.py
+++ b/services/ripper/arm_ripper/drive_poll.py
@@ -39,6 +39,7 @@ def read_drive_status(device_path: str) -> DriveState:
 # is the number of consecutive NOT_READY readings (≈ this × POLL_INTERVAL
 # seconds) past which we assume the disc was swapped and re-arm. A seated
 # disc's spin transition clears in one or two polls, well under this.
+# default fallback; production passes settings.ARM_NOT_READY_REARM_POLLS (Tier-4)
 DEFAULT_NOT_READY_REARM_POLLS = 3
 
 

--- a/services/ripper/arm_ripper/main.py
+++ b/services/ripper/arm_ripper/main.py
@@ -7,7 +7,7 @@ import httpx
 
 from arm_common import DriveMediaStatus, configure_service_logging
 from arm_ripper.backend_client import BackendClient
-from arm_ripper.config import MAKEMKV_KEYCHECK_INTERVAL_SECONDS, settings
+from arm_ripper.config import settings
 from arm_ripper.drive_poll import DriveState, InsertDetector, read_drive_status
 from arm_ripper.drive_status import probe_drive_media
 from arm_ripper.job_controller import JobController
@@ -106,11 +106,11 @@ async def makemkv_keycheck_loop(client: BackendClient) -> None:
             logger.warning("makemkv keycheck failed: %s", exc)
         except Exception:  # noqa: BLE001 — keycheck is best-effort; never let it kill the loop
             logger.exception("makemkv keycheck: unexpected error")
-        await asyncio.sleep(MAKEMKV_KEYCHECK_INTERVAL_SECONDS)
+        await asyncio.sleep(settings.MAKEMKV_KEYCHECK_INTERVAL_SECONDS)
 
 
 async def poll_loop(controller: JobController) -> None:
-    detector = InsertDetector()
+    detector = InsertDetector(not_ready_rearm_polls=settings.ARM_NOT_READY_REARM_POLLS)
     last_state: DriveState | None = None
     active_task: asyncio.Task[None] | None = None
     while True:

--- a/services/ripper/tests/test_config_tunables.py
+++ b/services/ripper/tests/test_config_tunables.py
@@ -1,0 +1,27 @@
+import os
+
+os.environ.setdefault("ARM_DRIVE_DEV", "/dev/sr0")
+os.environ.setdefault("ARM_BACKEND_URL", "https://backend")
+os.environ.setdefault("ARM_SERVICE_TOKEN", "tok")
+
+from arm_ripper.config import Settings  # noqa: E402
+
+
+def _settings(**over):
+    base = dict(ARM_DRIVE_DEV="/dev/sr0", ARM_BACKEND_URL="https://b", ARM_SERVICE_TOKEN="t")
+    base.update(over)
+    return Settings(**base)  # type: ignore[arg-type]
+
+
+def test_tunables_default_to_current_values():
+    s = _settings()
+    assert s.MAKEMKV_KEYCHECK_INTERVAL_SECONDS == 86400
+    assert s.ARM_NOT_READY_REARM_POLLS == 3
+
+
+def test_tunables_overridable(monkeypatch):
+    monkeypatch.setenv("MAKEMKV_KEYCHECK_INTERVAL_SECONDS", "3600")
+    monkeypatch.setenv("ARM_NOT_READY_REARM_POLLS", "5")
+    s = Settings(ARM_DRIVE_DEV="/dev/sr0", ARM_BACKEND_URL="https://b", ARM_SERVICE_TOKEN="t")  # type: ignore[arg-type]
+    assert s.MAKEMKV_KEYCHECK_INTERVAL_SECONDS == 3600
+    assert s.ARM_NOT_READY_REARM_POLLS == 5

--- a/services/ui-neu/frontend/src/lib/types/api.gen.ts
+++ b/services/ui-neu/frontend/src/lib/types/api.gen.ts
@@ -4856,7 +4856,7 @@ export type StreamTranscodeLogApiTranscodesTaskIdLogGetData = {
         /**
          * Limit
          */
-        limit?: number;
+        limit?: number | null;
     };
     url: '/api/transcodes/{task_id}/log';
 };
@@ -5975,7 +5975,7 @@ export type StreamJobLogsApiLogsJobIdGetData = {
         /**
          * Limit
          */
-        limit?: number;
+        limit?: number | null;
     };
     url: '/api/logs/{job_id}';
 };

--- a/services/ui-neu/scripts/codegen.sh
+++ b/services/ui-neu/scripts/codegen.sh
@@ -16,6 +16,14 @@ fi
 TMPSCHEMA="$V3_SNAPSHOT"
 
 cd "$REPO_ROOT/services/ui-neu/frontend"
+
+# `tsconfig.json` extends `./.svelte-kit/tsconfig.json`, a build artifact that
+# only exists after a SvelteKit sync/build. @hey-api/openapi-ts reads tsconfig
+# during output resolution, so on a fresh checkout (CI after bare `npm ci`, no
+# dev/build run yet) the missing `extends` target makes codegen fail with
+# "Couldn't read tsconfig". Generate it first so codegen is reproducible.
+npx svelte-kit sync
+
 npx --yes @hey-api/openapi-ts \
     --input "$TMPSCHEMA" \
     --output src/lib/types/api.gen.ts \

--- a/services/ui/openapi.snapshot.json
+++ b/services/ui/openapi.snapshot.json
@@ -5431,7 +5431,8 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 {
                   "type": "null"

--- a/services/ui/openapi.snapshot.json
+++ b/services/ui/openapi.snapshot.json
@@ -3477,9 +3477,15 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 1000,
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Limit"
             }
           },
@@ -5423,8 +5429,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
-              "default": 1000,
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Limit"
             }
           },

--- a/services/ui/src/__tests__/config-fields-guard.spec.ts
+++ b/services/ui/src/__tests__/config-fields-guard.spec.ts
@@ -1,23 +1,31 @@
-import { describe, it, expect } from 'vitest';
-import { CONFIG_FORM_KEYS } from '../views/configFormFields';
+import { describe, it, expect } from 'vitest'
+import { CONFIG_FORM_KEYS } from '../views/configFormFields'
 
 // The editable config keys the form is expected to render. Mirrors the backend
 // CONFIG_FIELD_META editable surface. If the backend changes its editable keys,
 // update BOTH this list and CONFIG_FORM_KEYS in the same change.
 const EXPECTED_EDITABLE = [
-  'tmdb_api_key', 'omdb_api_key', 'tvdb_api_key', 'makemkv_key',
-  'musicbrainz_user_agent', 'metadata_provider', 'auto_transcode_on_idle',
-  'auto_rip_on_insert', 'block_on_miss', 'ripping_paused', 'notifications_enabled',
-];
-const FORBIDDEN = ['default_retention_policy', 'notification_apprise_urls'];
+  'tmdb_api_key',
+  'omdb_api_key',
+  'tvdb_api_key',
+  'makemkv_key',
+  'musicbrainz_user_agent',
+  'metadata_provider',
+  'auto_transcode_on_idle',
+  'auto_rip_on_insert',
+  'block_on_miss',
+  'ripping_paused',
+  'notifications_enabled',
+]
+const FORBIDDEN = ['default_retention_policy', 'notification_apprise_urls']
 
 describe('config form field guard', () => {
   it('binds exactly the expected editable config keys', () => {
-    expect(new Set(CONFIG_FORM_KEYS)).toEqual(new Set(EXPECTED_EDITABLE));
-  });
+    expect(new Set(CONFIG_FORM_KEYS)).toEqual(new Set(EXPECTED_EDITABLE))
+  })
   it('does not bind the hidden/removed keys', () => {
     for (const k of FORBIDDEN) {
-      expect(CONFIG_FORM_KEYS as readonly string[]).not.toContain(k);
+      expect(CONFIG_FORM_KEYS as readonly string[]).not.toContain(k)
     }
-  });
-});
+  })
+})

--- a/services/ui/src/views/configFormFields.ts
+++ b/services/ui/src/views/configFormFields.ts
@@ -3,7 +3,7 @@
 // removes an editable config key, update this list in the same change — the
 // config-fields-guard test pins it so a field can't be silently dropped from the
 // form again (settings audit §1.3 / structural fix 3).
-import type { ConfigUpdateRequest } from '../api/types';
+import type { ConfigUpdateRequest } from '../api/types'
 
 export const CONFIG_FORM_KEYS = [
   'tmdb_api_key',
@@ -17,4 +17,4 @@ export const CONFIG_FORM_KEYS = [
   'block_on_miss',
   'ripping_paused',
   'notifications_enabled',
-] as const satisfies readonly (keyof ConfigUpdateRequest)[];
+] as const satisfies readonly (keyof ConfigUpdateRequest)[]


### PR DESCRIPTION
Stacks on `feat/ui-neu-full` (#20). Settings-audit follow-ups making hardcoded external endpoints/tunables operator-configurable via env vars — each defaulting to its current literal, so **zero behavior change when unset**.

## PR-3 — Tier-3 air-gap configurability
- **Metadata base URLs** (`ARM_TMDB_BASE_URL`, `ARM_OMDB_BASE_URL`, `ARM_TVDB_BASE_URL`, `ARM_MUSICBRAINZ_BASE_URL`, `ARM_ARMSERVER_BASE_URL`) — the 5 provider clients read their base URL from settings (via a `_base_url()` accessor mirroring `image_cache._cache_dir()`), so air-gapped/mirror/regional deployments can point them at an internal proxy.
- **`ARM_EXTRA_IMAGE_HOSTS`** — additive image-proxy allowlist extension (`defaults | extras`, never replacing the built-in set — preserves the SSRF guard). Mirrors the `ARM_ALLOWED_ORIGINS` NoDecode comma-split.

## PR-4a — Tier-4 env tunables
- **Image-cache caps** — `ARM_IMAGE_CACHE_MAX_ENTRIES` / `_MAX_BYTES` / `_TTL_SECONDS`.
- **Log query/zip caps** — `ARM_LOG_PER_FILE_DEFAULT` / `_HARD_CAP` / `ARM_LOG_ZIP_PER_ENTRY_LINE_CAP` / `_BYTE_CAP`. The `limit` query param on the logs + transcode-log endpoints became `int | None` (default resolved in-body, since a default-arg snapshots at import); OpenAPI + ui-neu types regenerated accordingly.
- **Ripper tunables** — `MAKEMKV_KEYCHECK_INTERVAL_SECONDS` (moved into the ripper `Settings`) + `ARM_NOT_READY_REARM_POLLS` (drive insert-detection rearm window).

All documented in `.env.example` (commented defaults); the `.env.example` discovery-contract guard stays green.

## Deferred (not in this PR)
**Per-preset title-duration thresholds** — the one Tier-4 row the audit rated lowest-confidence (it touches the rip-preset validation contract + `select_tracks` + the wire contract). Written up as a standalone proposal to decide build-vs-skip separately, rather than bolting speculative complexity onto this PR.

## Test plan
- [x] Full Python suite: **1358 passed**
- [x] ruff / mypy clean (pre-commit)
- [x] OpenAPI snapshot + ui-neu `api.gen.ts` regenerated; no drift
- [x] svelte-check: 0 errors
- [x] env-docs discovery-contract guard green

🤖 Generated with [Claude Code](https://claude.com/claude-code)