### PR TITLE
feat: Tier-16 — default to a MusicBrainz-compliant User-Agent

### DIFF
--- a/packages/arm_common/arm_common/__init__.py
+++ b/packages/arm_common/arm_common/__init__.py
@@ -27,6 +27,7 @@ from arm_common.enums import (
     VideoCodec,
 )
 from arm_common.models import (
+    DEFAULT_MUSICBRAINZ_USER_AGENT,
     Config,
     DiscFingerprint,
     Drive,
@@ -47,6 +48,7 @@ from arm_common.models import (
 from arm_common.ulid import new_id
 
 __all__ = [
+    "DEFAULT_MUSICBRAINZ_USER_AGENT",
     "Config",
     "ContainerFormat",
     "DiscFingerprint",

--- a/packages/arm_common/arm_common/models/__init__.py
+++ b/packages/arm_common/arm_common/models/__init__.py
@@ -1,4 +1,4 @@
-from arm_common.models.config import Config
+from arm_common.models.config import DEFAULT_MUSICBRAINZ_USER_AGENT, Config
 from arm_common.models.disc_fingerprint import DiscFingerprint
 from arm_common.models.drive import Drive
 from arm_common.models.event import Event
@@ -16,6 +16,7 @@ from arm_common.models.transcode_task import TranscodeTask
 from arm_common.models.user import User
 
 __all__ = [
+    "DEFAULT_MUSICBRAINZ_USER_AGENT",
     "Config",
     "DiscFingerprint",
     "Drive",

--- a/packages/arm_common/arm_common/models/config.py
+++ b/packages/arm_common/arm_common/models/config.py
@@ -7,6 +7,13 @@ from sqlmodel import Field, SQLModel
 from arm_common.models._columns import enum_column, updated_at_column
 from arm_common.enums import RetentionPolicy
 
+# MusicBrainz 403s any User-Agent that doesn't follow their etiquette guide's
+# `AppName/version ( contact )` shape — a bare token like `armv3` is rejected.
+# This well-formed default keeps the first audio-CD rip working on a fresh
+# install; it is the single source of truth for the model default AND the
+# router fallback when an operator hasn't set their own.
+DEFAULT_MUSICBRAINZ_USER_AGENT = "ARM/3.0.0 ( https://github.com/automatic-ripping-machine/automatic-ripping-machine )"
+
 
 class Config(SQLModel, table=True):
     __tablename__ = "config"
@@ -28,12 +35,9 @@ class Config(SQLModel, table=True):
     makemkv_key_valid: bool | None = Field(sa_column=Column(Boolean, nullable=True))
     makemkv_key_state: str | None = Field(sa_column=Column(String, nullable=True))
     makemkv_key_checked_at: datetime | None = Field(sa_column=Column(DateTime(timezone=True), nullable=True))
-    # MusicBrainz requires a non-empty User-Agent (they 403 blank UAs); `armv3`
-    # is a reasonable shared default that won't blow up the first audio-CD rip
-    # on a fresh install. Operators are still encouraged to override with an
-    # app-name-plus-contact-info string per MB's etiquette guide — see the UI
-    # form's placeholder hint.
-    musicbrainz_user_agent: str | None = Field(default="armv3")
+    # See DEFAULT_MUSICBRAINZ_USER_AGENT above — a bare token 403s; operators are
+    # still encouraged to override with their own contact info (UI placeholder hint).
+    musicbrainz_user_agent: str | None = Field(default=DEFAULT_MUSICBRAINZ_USER_AGENT)
     # Persisted metadata provider for the identify flow (search + detail).
     # Default `tmdb` — free, effectively unlimited, richer than OMDb. Validated
     # app-side to {tmdb, omdb}; tvdb/makemkv are key-test-only, not search providers.

--- a/services/backend/arm_backend/routers/metadata.py
+++ b/services/backend/arm_backend/routers/metadata.py
@@ -22,7 +22,7 @@ from arm_backend.metadata.omdb import OMDBClient
 from arm_backend.metadata.tmdb import TMDBClient
 from arm_backend.metadata.tvdb import TVDBClient
 from arm_backend.seeders import CONFIG_SINGLETON_ID
-from arm_common import Config, User
+from arm_common import DEFAULT_MUSICBRAINZ_USER_AGENT, Config, User
 from arm_common.schemas import (
     MetadataCandidate,
     MetadataKeyTestResponse,
@@ -208,7 +208,7 @@ async def search_music(
     db: AsyncSession = Depends(get_session),
 ) -> MetadataSearchResponse:
     cfg = (await db.execute(select(Config).where(col(Config.id) == CONFIG_SINGLETON_ID))).scalar_one_or_none()
-    ua = (cfg.musicbrainz_user_agent if cfg else None) or "armv3"
+    ua = (cfg.musicbrainz_user_agent if cfg else None) or DEFAULT_MUSICBRAINZ_USER_AGENT
     http: httpx.AsyncClient = request.app.state.http
     try:
         results = await MusicBrainzClient(ua, http).search_releases(query)
@@ -227,7 +227,7 @@ async def music_release_detail(
     db: AsyncSession = Depends(get_session),
 ) -> MetadataReleaseDetail:
     cfg = (await db.execute(select(Config).where(col(Config.id) == CONFIG_SINGLETON_ID))).scalar_one_or_none()
-    ua = (cfg.musicbrainz_user_agent if cfg else None) or "armv3"
+    ua = (cfg.musicbrainz_user_agent if cfg else None) or DEFAULT_MUSICBRAINZ_USER_AGENT
     http: httpx.AsyncClient = request.app.state.http
     try:
         result = await MusicBrainzClient(ua, http).get_release(release_id)


### PR DESCRIPTION
## Problem
MusicBrainz **403s** any `User-Agent` that doesn't follow their [etiquette guide](https://musicbrainz.org/doc/MusicBrainz_API/Rate_Limiting)'s `AppName/version ( contact )` shape. The config default was the bare token `armv3`, so **every audio-CD identify** (music search + release detail) failed on a fresh install with `musicbrainz status=403`.

Found while driving a real CD identify (The Beatles – Abbey Road) against the dev stack: search returned `{"candidates": [], "detail": "musicbrainz status=403"}`.

## Fix
- Introduce `DEFAULT_MUSICBRAINZ_USER_AGENT` in `arm_common` as the single source of truth, a well-formed `ARM/3.0.0 ( <repo url> )`.
- Use it as the `Config.musicbrainz_user_agent` model default (so a freshly seeded config works out of the box) **and** as the metadata router fallback when an operator hasn't set their own (replacing two `or "armv3"` literals).
- Correct the now-inaccurate comment that claimed `armv3` "won't blow up the first audio-CD rip".

## No migration
Existing config rows keep their stored value; operators are still encouraged to override with their own contact info (UI placeholder hint). Fresh installs get the working default.

## Verification
- New default UA → **HTTP 200** from musicbrainz.org; old `armv3` → **403** (confirmed against the live service).
- A fresh `Config()` now carries the compliant default.
- Backend suites green (metadata router, seeders, config); OpenAPI snapshot unchanged (DB-column default, not a wire-schema field).

## Related PRs
This same fix is **also bundled in #25** (CD music-matching), which cherry-picked it because its live music-search flow needs the compliant UA. If #25 merges first, this PR becomes a no-op (or close it); if this merges first, #25's copy de-dupes on rebase. Either order is safe — they make the identical change to `Config.musicbrainz_user_agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)