### PR TITLE
feat: Tier-17 — CD music-matching UX (search, match, apply) with multi-disc support

### DIFF
--- a/packages/arm_common/arm_common/__init__.py
+++ b/packages/arm_common/arm_common/__init__.py
@@ -28,6 +28,7 @@ from arm_common.enums import (
     VideoCodec,
 )
 from arm_common.models import (
+    DEFAULT_MUSICBRAINZ_USER_AGENT,
     Config,
     DiscFingerprint,
     Drive,
@@ -48,6 +49,7 @@ from arm_common.models import (
 from arm_common.ulid import new_id
 
 __all__ = [
+    "DEFAULT_MUSICBRAINZ_USER_AGENT",
     "Config",
     "ContainerFormat",
     "DiscFingerprint",

--- a/packages/arm_common/arm_common/models/__init__.py
+++ b/packages/arm_common/arm_common/models/__init__.py
@@ -1,4 +1,4 @@
-from arm_common.models.config import Config
+from arm_common.models.config import DEFAULT_MUSICBRAINZ_USER_AGENT, Config
 from arm_common.models.disc_fingerprint import DiscFingerprint
 from arm_common.models.drive import Drive
 from arm_common.models.event import Event
@@ -16,6 +16,7 @@ from arm_common.models.transcode_task import TranscodeTask
 from arm_common.models.user import User
 
 __all__ = [
+    "DEFAULT_MUSICBRAINZ_USER_AGENT",
     "Config",
     "DiscFingerprint",
     "Drive",

--- a/packages/arm_common/arm_common/models/config.py
+++ b/packages/arm_common/arm_common/models/config.py
@@ -7,6 +7,13 @@ from sqlmodel import Field, SQLModel
 from arm_common.models._columns import enum_column, updated_at_column
 from arm_common.enums import RetentionPolicy
 
+# MusicBrainz 403s any User-Agent that doesn't follow their etiquette guide's
+# `AppName/version ( contact )` shape — a bare token like `armv3` is rejected.
+# This well-formed default keeps the first audio-CD rip working on a fresh
+# install; it is the single source of truth for the model default AND the
+# router fallback when an operator hasn't set their own.
+DEFAULT_MUSICBRAINZ_USER_AGENT = "ARM/3.0.0 ( https://github.com/automatic-ripping-machine/automatic-ripping-machine )"
+
 
 class Config(SQLModel, table=True):
     __tablename__ = "config"
@@ -35,12 +42,9 @@ class Config(SQLModel, table=True):
     community_keydb_state: str | None = Field(sa_column=Column(String, nullable=True))
     community_keydb_vuk_count: int | None = Field(sa_column=Column(Integer, nullable=True))
     community_keydb_checked_at: datetime | None = Field(sa_column=Column(DateTime(timezone=True), nullable=True))
-    # MusicBrainz requires a non-empty User-Agent (they 403 blank UAs); `armv3`
-    # is a reasonable shared default that won't blow up the first audio-CD rip
-    # on a fresh install. Operators are still encouraged to override with an
-    # app-name-plus-contact-info string per MB's etiquette guide — see the UI
-    # form's placeholder hint.
-    musicbrainz_user_agent: str | None = Field(default="armv3")
+    # See DEFAULT_MUSICBRAINZ_USER_AGENT above — a bare token 403s; operators are
+    # still encouraged to override with their own contact info (UI placeholder hint).
+    musicbrainz_user_agent: str | None = Field(default=DEFAULT_MUSICBRAINZ_USER_AGENT)
     # Persisted metadata provider for the identify flow (search + detail).
     # Default `tmdb` — free, effectively unlimited, richer than OMDb. Validated
     # app-side to {tmdb, omdb}; tvdb/makemkv are key-test-only, not search providers.

--- a/packages/arm_common/arm_common/models/job.py
+++ b/packages/arm_common/arm_common/models/job.py
@@ -26,6 +26,11 @@ class Job(SQLModel, table=True):
     # in migration 0006 to make the multi-fingerprint design first-class.
     title: str | None = Field(default=None)
     year: int | None = Field(sa_column=Column(Integer, nullable=True))
+    # Multi-disc CD sets: which disc of the set this job ripped (1-based) and
+    # the set size. Null = single-disc / unknown. Set at identify (resolve) or
+    # corrected later via PATCH. No Postgres enum — plain nullable ints.
+    disc_number: int | None = Field(sa_column=Column(Integer, nullable=True))
+    disc_total: int | None = Field(sa_column=Column(Integer, nullable=True))
     # Poster shown in the UI. `poster_url` is computed at identify time
     # (TMDB / OMDB / Cover Art Archive). `poster_url_manual` is a user
     # override editable from JobDetail; the UI prefers it when set.

--- a/packages/arm_common/arm_common/schemas/jobs.py
+++ b/packages/arm_common/arm_common/schemas/jobs.py
@@ -114,13 +114,15 @@ class TrackEditRequest(BaseModel):
 
 
 class JobUpdateRequest(BaseModel):
-    """PATCH /api/jobs/{id} body. `poster_url_manual` edits the job; `tracks`
-    applies per-track operator edits in the same atomic save. The JOB's
+    """PATCH /api/jobs/{id} body. `poster_url_manual` + disc fields edit the job;
+    `tracks` applies per-track operator edits in the same atomic save. The JOB's
     title/year still live behind identify/resolve."""
 
     model_config = ConfigDict(extra="forbid")
 
     poster_url_manual: str | None = None
+    disc_number: int | None = None
+    disc_total: int | None = None
     tracks: list[TrackEditRequest] | None = None
 
 

--- a/packages/arm_common/arm_common/schemas/jobs.py
+++ b/packages/arm_common/arm_common/schemas/jobs.py
@@ -9,6 +9,8 @@ from arm_common.enums import DiscType, JobStatus, SessionApplicationStatus, Trac
 class ResolveRequest(BaseModel):
     title: str
     year: int | None = None
+    disc_number: int | None = None
+    disc_total: int | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/packages/arm_common/arm_common/schemas/jobs.py
+++ b/packages/arm_common/arm_common/schemas/jobs.py
@@ -81,6 +81,8 @@ class JobView(BaseModel):
     status: JobStatus
     title: str | None
     year: int | None
+    disc_number: int | None = None
+    disc_total: int | None = None
     # Computed at identify; UI prefers `poster_url_manual` if set.
     poster_url: str | None = None
     poster_url_manual: str | None = None

--- a/packages/arm_common/arm_common/schemas/metadata.py
+++ b/packages/arm_common/arm_common/schemas/metadata.py
@@ -24,6 +24,8 @@ class MetadataCandidate(BaseModel):
 class MetadataReleaseTrack(BaseModel):
     position: int | None = None
     title: str
+    length_ms: int | None = None
+    disc_number: int | None = None
 
 
 class MetadataReleaseDetail(BaseModel):
@@ -32,6 +34,13 @@ class MetadataReleaseDetail(BaseModel):
     artist: str | None = None
     year: int | None = None
     poster_url: str | None = None
+    catalog_number: str | None = None
+    barcode: str | None = None
+    country: str | None = None
+    format: str | None = None
+    status: str | None = None
+    disc_count: int | None = None
+    track_count: int | None = None
     tracks: list[MetadataReleaseTrack] = Field(default_factory=list)
 
 

--- a/services/backend/arm_backend/metadata/musicbrainz.py
+++ b/services/backend/arm_backend/metadata/musicbrainz.py
@@ -92,8 +92,8 @@ class MusicBrainzClient:
         # extract_poster_url() can still derive the Cover Art Archive URL
         # from release["id"], and downstream debugging has the full payload.
         artist = _join_artist_credit(top.get("artist-credit") or [])
-        medium = _pick_medium_for_disc(top.get("media") or [], disc_id)
-        tracks = _extract_tracks(medium)
+        medium, disc_number = _pick_medium_for_disc(top.get("media") or [], disc_id)
+        tracks = _extract_tracks(medium, disc_number)
 
         payload: dict[str, Any] = {
             "artist": artist,
@@ -122,39 +122,60 @@ class MusicBrainzClient:
         year_val = _parse_year(body.get("date") or "")
         artist = _join_artist_credit(body.get("artist-credit") or [])
         media = body.get("media") or []
-        tracks = _extract_tracks(media[0] if media else None)
+        tracks: list[dict[str, Any]] = []
+        for i, medium in enumerate(media):
+            tracks.extend(_extract_tracks(medium, i + 1))
+        label_info = body.get("label-info") or []
+        catalog_number = None
+        if label_info and isinstance(label_info[0], dict):
+            catalog_number = label_info[0].get("catalog-number")
+        fmt = media[0].get("format") if media and isinstance(media[0], dict) else None
         payload: dict[str, Any] = {
             "artist": artist,
             "album": title_val,
             "tracks": tracks,
+            "catalog_number": catalog_number,
+            "format": fmt,
+            "disc_count": len(media),
+            "track_count": len(tracks),
             **body,
         }
         return MetadataResult(title=title_val, year=year_val, kind="music", payload=payload)
 
-    async def search_releases(self, query: str, limit: int = 10) -> list[MetadataResult]:
-        """Lucene release search for interactive lookup. Returns up to `limit`."""
+    async def search_releases(
+        self, query: str, limit: int = 10, artist: str | None = None, track_count: int | None = None
+    ) -> list[MetadataResult]:
+        """Lucene release search for interactive lookup. Returns up to `limit`.
+        `artist` and `track_count`, when given, narrow the Lucene query."""
+        lucene = query
+        if artist:
+            lucene = f'{query} AND artist:"{_escape_lucene(artist)}"'
+        if track_count is not None:
+            lucene = f"{lucene} AND tracks:{track_count}"
         body = await self._get(
             "/release",
-            params={"query": query, "fmt": "json", "limit": limit},
+            params={"query": lucene, "fmt": "json", "limit": limit},
         )
-
         results: list[MetadataResult] = []
-        # MB's `limit` query param is advisory; re-cap client-side as a guard.
         for rel in (body.get("releases") or [])[:limit]:
             title = rel.get("title")
             if not title:
                 continue
             year = _parse_year(rel.get("date") or "")
-            artist = _join_artist_credit(rel.get("artist-credit") or [])
-            payload: dict[str, Any] = {"artist": artist, "album": title, **rel}
+            artist_name = _join_artist_credit(rel.get("artist-credit") or [])
+            payload: dict[str, Any] = {"artist": artist_name, "album": title, **rel}
             results.append(MetadataResult(title=title, year=year, kind="music", payload=payload))
-
         return results
 
 
 def _parse_year(date: str) -> int | None:
     """Year from a MusicBrainz date string ("1973-03-01" -> 1973), or None."""
     return int(date[:4]) if date[:4].isdigit() else None
+
+
+def _escape_lucene(term: str) -> str:
+    """Escape Lucene double-quotes/backslashes so a quoted phrase term is safe."""
+    return term.replace("\\", "\\\\").replace('"', '\\"')
 
 
 def _join_artist_credit(credit: list[dict[str, Any]]) -> str:
@@ -176,31 +197,21 @@ def _join_artist_credit(credit: list[dict[str, Any]]) -> str:
     return "".join(parts).strip()
 
 
-def _pick_medium_for_disc(media: list[dict[str, Any]], disc_id: str) -> dict[str, Any] | None:
-    """Pick the medium whose `discs[].id` matches `disc_id`.
-
-    For multi-disc releases (e.g. a 2-CD album), MB returns each medium
-    separately and tags each with its own disc-id list. Matching by disc-id
-    is the only way to know whether we're looking at Disc 1 or Disc 2.
-    Falls back to `media[0]` when no disc-id match is found — single-disc
-    releases sometimes omit the `discs[]` array entirely.
-    """
-    for medium in media:
+def _pick_medium_for_disc(media: list[dict[str, Any]], disc_id: str) -> tuple[dict[str, Any] | None, int]:
+    """Return (medium, 1-based disc_number) for the medium whose discs[].id matches
+    disc_id; fall back to (media[0], 1). (None, 1) when media is empty."""
+    for i, medium in enumerate(media):
         for disc in medium.get("discs") or []:
             if isinstance(disc, dict) and disc.get("id") == disc_id:
-                return medium
+                return medium, i + 1
     if media:
-        return media[0]
-    return None
+        return media[0], 1
+    return None, 1
 
 
-def _extract_tracks(medium: dict[str, Any] | None) -> list[dict[str, Any]]:
-    """Build the `metadata_json["tracks"]` array consumed by `_build_track_ctx`.
-
-    Each entry is `{"title": str, "position": int}`. Position is parsed from
-    the string MB returns; a non-integer position falls through with the raw
-    string preserved.
-    """
+def _extract_tracks(medium: dict[str, Any] | None, disc_number: int) -> list[dict[str, Any]]:
+    """Build `metadata_json["tracks"]` entries for one medium (disc). Each entry
+    is {title, position?, length_ms, disc_number}. `length` from MB is already ms."""
     if medium is None:
         return []
     out: list[dict[str, Any]] = []
@@ -214,5 +225,8 @@ def _extract_tracks(medium: dict[str, Any] | None) -> list[dict[str, Any]]:
             entry["position"] = int(position)
         elif isinstance(position, int):
             entry["position"] = position
+        length = raw.get("length")
+        entry["length_ms"] = length if isinstance(length, int) else None
+        entry["disc_number"] = disc_number
         out.append(entry)
     return out

--- a/services/backend/arm_backend/routers/jobs.py
+++ b/services/backend/arm_backend/routers/jobs.py
@@ -648,6 +648,8 @@ async def resolve(
 
     job.title = req.title
     job.year = req.year
+    job.disc_number = req.disc_number
+    job.disc_total = req.disc_total
     job.metadata_json = new_metadata
     if job.status in _RESOLVABLE_STATUSES_PROMOTE:
         job.status = JobStatus.IDENTIFIED

--- a/services/backend/arm_backend/routers/metadata.py
+++ b/services/backend/arm_backend/routers/metadata.py
@@ -22,7 +22,7 @@ from arm_backend.metadata.omdb import OMDBClient
 from arm_backend.metadata.tmdb import TMDBClient
 from arm_backend.metadata.tvdb import TVDBClient
 from arm_backend.seeders import CONFIG_SINGLETON_ID
-from arm_common import Config, User
+from arm_common import DEFAULT_MUSICBRAINZ_USER_AGENT, Config, User
 from arm_common.schemas import (
     MetadataCandidate,
     MetadataKeyTestResponse,
@@ -208,7 +208,7 @@ async def search_music(
     db: AsyncSession = Depends(get_session),
 ) -> MetadataSearchResponse:
     cfg = (await db.execute(select(Config).where(col(Config.id) == CONFIG_SINGLETON_ID))).scalar_one_or_none()
-    ua = (cfg.musicbrainz_user_agent if cfg else None) or "armv3"
+    ua = (cfg.musicbrainz_user_agent if cfg else None) or DEFAULT_MUSICBRAINZ_USER_AGENT
     http: httpx.AsyncClient = request.app.state.http
     try:
         results = await MusicBrainzClient(ua, http).search_releases(query)
@@ -227,7 +227,7 @@ async def music_release_detail(
     db: AsyncSession = Depends(get_session),
 ) -> MetadataReleaseDetail:
     cfg = (await db.execute(select(Config).where(col(Config.id) == CONFIG_SINGLETON_ID))).scalar_one_or_none()
-    ua = (cfg.musicbrainz_user_agent if cfg else None) or "armv3"
+    ua = (cfg.musicbrainz_user_agent if cfg else None) or DEFAULT_MUSICBRAINZ_USER_AGENT
     http: httpx.AsyncClient = request.app.state.http
     try:
         result = await MusicBrainzClient(ua, http).get_release(release_id)

--- a/services/backend/arm_backend/routers/metadata.py
+++ b/services/backend/arm_backend/routers/metadata.py
@@ -204,6 +204,8 @@ async def lookup_metadata(
 async def search_music(
     request: Request,
     query: str,
+    artist: str | None = None,
+    track_count: int | None = None,
     _: User = Depends(require_jwt),
     db: AsyncSession = Depends(get_session),
 ) -> MetadataSearchResponse:
@@ -211,7 +213,7 @@ async def search_music(
     ua = (cfg.musicbrainz_user_agent if cfg else None) or DEFAULT_MUSICBRAINZ_USER_AGENT
     http: httpx.AsyncClient = request.app.state.http
     try:
-        results = await MusicBrainzClient(ua, http).search_releases(query)
+        results = await MusicBrainzClient(ua, http).search_releases(query, artist=artist, track_count=track_count)
     except (MetaLookupError, LookupTimeout) as exc:
         return MetadataSearchResponse(candidates=[], detail=str(exc))
     except httpx.HTTPError as exc:
@@ -243,12 +245,27 @@ async def music_release_detail(
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=f"musicbrainz unavailable: {exc}") from exc
     payload = result.payload or {}
     raw_tracks = payload.get("tracks") or []
-    tracks = [MetadataReleaseTrack(position=t.get("position"), title=t.get("title") or "") for t in raw_tracks]
+    tracks = [
+        MetadataReleaseTrack(
+            position=t.get("position"),
+            title=t.get("title") or "",
+            length_ms=t.get("length_ms"),
+            disc_number=t.get("disc_number"),
+        )
+        for t in raw_tracks
+    ]
     return MetadataReleaseDetail(
         release_id=release_id,
         title=result.title,
         artist=payload.get("artist"),
         year=result.year,
         poster_url=extract_poster_url(result),
+        catalog_number=payload.get("catalog_number"),
+        barcode=payload.get("barcode"),
+        country=payload.get("country"),
+        format=payload.get("format"),
+        status=payload.get("status"),
+        disc_count=payload.get("disc_count"),
+        track_count=payload.get("track_count"),
         tracks=tracks,
     )

--- a/services/backend/migrations/versions/0021_job_disc_number.py
+++ b/services/backend/migrations/versions/0021_job_disc_number.py
@@ -1,0 +1,30 @@
+"""Add disc_number and disc_total columns to jobs table.
+
+Stores the disc index and total disc count for multi-disc CD sets,
+populated during music metadata matching.
+
+Revision ID: 0021_job_disc_number
+Revises: 0020_track_operator_fields
+Create Date: 2026-06-20
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0021_job_disc_number"
+down_revision: Union[str, None] = "0020_track_operator_fields"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("jobs", sa.Column("disc_number", sa.Integer(), nullable=True))
+    op.add_column("jobs", sa.Column("disc_total", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("jobs", "disc_total")
+    op.drop_column("jobs", "disc_number")

--- a/services/backend/migrations/versions/0022_job_disc_number.py
+++ b/services/backend/migrations/versions/0022_job_disc_number.py
@@ -3,8 +3,8 @@
 Stores the disc index and total disc count for multi-disc CD sets,
 populated during music metadata matching.
 
-Revision ID: 0021_job_disc_number
-Revises: 0020_track_operator_fields
+Revision ID: 0022_job_disc_number
+Revises: 0021_community_keydb_fields
 Create Date: 2026-06-20
 
 """
@@ -14,8 +14,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "0021_job_disc_number"
-down_revision: Union[str, None] = "0020_track_operator_fields"
+revision: str = "0022_job_disc_number"
+down_revision: Union[str, None] = "0021_community_keydb_fields"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/backend/tests/test_job_disc_fields.py
+++ b/services/backend/tests/test_job_disc_fields.py
@@ -1,0 +1,35 @@
+from arm_common import Job
+from arm_common.enums import JobStatus
+from arm_common.schemas.jobs import JobView
+
+
+def test_job_model_has_disc_fields_defaulting_none():
+    job = Job(drive_id="drv_1", disc_type="cd", status=JobStatus.CREATED, resumed_from_crash=False)
+    assert job.disc_number is None
+    assert job.disc_total is None
+
+
+def test_job_round_trips_disc_fields():
+    job = Job(
+        drive_id="drv_1",
+        disc_type="cd",
+        disc_number=2,
+        disc_total=3,
+        status=JobStatus.CREATED,
+        resumed_from_crash=False,
+    )
+    assert (job.disc_number, job.disc_total) == (2, 3)
+
+
+def test_jobview_exposes_disc_fields():
+    job = Job(
+        drive_id="drv_1",
+        disc_type="cd",
+        disc_number=1,
+        disc_total=2,
+        status=JobStatus.CREATED,
+        resumed_from_crash=False,
+    )
+    view = JobView.model_validate(job)
+    assert view.disc_number == 1
+    assert view.disc_total == 2

--- a/services/backend/tests/test_metadata_clients.py
+++ b/services/backend/tests/test_metadata_clients.py
@@ -957,9 +957,7 @@ async def test_get_release_success(http_client):
     assert result.year == 1973
     assert result.kind == "music"
     assert result.payload["artist"] == "Pink Floyd"
-    assert result.payload["tracks"] == [
-        {"title": "Speak to Me", "position": 1, "length_ms": None, "disc_number": 1}
-    ]
+    assert result.payload["tracks"] == [{"title": "Speak to Me", "position": 1, "length_ms": None, "disc_number": 1}]
 
 
 @respx.mock
@@ -983,19 +981,28 @@ async def test_get_release_missing_title_raises(http_client):
 @respx.mock
 async def test_get_release_extracts_length_and_release_fields(http_client):
     respx.get("https://musicbrainz.org/ws/2/release/mbid-2").mock(
-        return_value=httpx.Response(200, json={
-            "id": "mbid-2", "title": "Abbey Road", "date": "1969-09-26",
-            "artist-credit": [{"name": "The Beatles"}],
-            "country": "GB", "barcode": "0094638246619", "status": "Official",
-            "label-info": [{"catalog-number": "PCS 7088"}],
-            "media": [{
-                "format": "CD",
-                "tracks": [
-                    {"position": "1", "title": "Come Together", "length": 259000},
-                    {"position": "2", "title": "Something", "length": 182000},
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "mbid-2",
+                "title": "Abbey Road",
+                "date": "1969-09-26",
+                "artist-credit": [{"name": "The Beatles"}],
+                "country": "GB",
+                "barcode": "0094638246619",
+                "status": "Official",
+                "label-info": [{"catalog-number": "PCS 7088"}],
+                "media": [
+                    {
+                        "format": "CD",
+                        "tracks": [
+                            {"position": "1", "title": "Come Together", "length": 259000},
+                            {"position": "2", "title": "Something", "length": 182000},
+                        ],
+                    }
                 ],
-            }],
-        })
+            },
+        )
     )
     result = await MusicBrainzClient("armv3", http_client).get_release("mbid-2")
     p = result.payload
@@ -1012,14 +1019,19 @@ async def test_get_release_extracts_length_and_release_fields(http_client):
 @respx.mock
 async def test_get_release_multi_disc_tags_disc_number(http_client):
     respx.get("https://musicbrainz.org/ws/2/release/mbid-3").mock(
-        return_value=httpx.Response(200, json={
-            "id": "mbid-3", "title": "The Wall", "date": "1979",
-            "artist-credit": [{"name": "Pink Floyd"}],
-            "media": [
-                {"format": "CD", "tracks": [{"position": "1", "title": "In the Flesh?", "length": 199000}]},
-                {"format": "CD", "tracks": [{"position": "1", "title": "Hey You", "length": 280000}]},
-            ],
-        })
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "mbid-3",
+                "title": "The Wall",
+                "date": "1979",
+                "artist-credit": [{"name": "Pink Floyd"}],
+                "media": [
+                    {"format": "CD", "tracks": [{"position": "1", "title": "In the Flesh?", "length": 199000}]},
+                    {"format": "CD", "tracks": [{"position": "1", "title": "Hey You", "length": 280000}]},
+                ],
+            },
+        )
     )
     p = (await MusicBrainzClient("armv3", http_client).get_release("mbid-3")).payload
     assert p["disc_count"] == 2

--- a/services/backend/tests/test_metadata_clients.py
+++ b/services/backend/tests/test_metadata_clients.py
@@ -139,9 +139,9 @@ async def test_musicbrainz_extracts_artist_album_tracks(http_client):
     assert result.payload["artist"] == "Pink Floyd"
     assert result.payload["album"] == "Dark Side of the Moon"
     assert result.payload["tracks"] == [
-        {"title": "Speak to Me", "position": 1},
-        {"title": "Breathe", "position": 2},
-        {"title": "On the Run", "position": 3},
+        {"title": "Speak to Me", "position": 1, "length_ms": None, "disc_number": 1},
+        {"title": "Breathe", "position": 2, "length_ms": None, "disc_number": 1},
+        {"title": "On the Run", "position": 3, "length_ms": None, "disc_number": 1},
     ]
     # release["id"] is preserved by spread — extract_poster_url derives
     # the Cover Art Archive URL from it.
@@ -221,7 +221,7 @@ async def test_musicbrainz_single_disc_release_no_discs_array(http_client):
     )
     client = MusicBrainzClient("arm-test/0.0 (test@example.com)", http_client)
     result = await client.lookup_disc_id("xyz")
-    assert result.payload["tracks"] == [{"title": "Opener", "position": 1}]
+    assert result.payload["tracks"] == [{"title": "Opener", "position": 1, "length_ms": None, "disc_number": 1}]
 
 
 @respx.mock
@@ -366,9 +366,9 @@ async def test_musicbrainz_tracks_drop_entries_without_title(http_client):
     client = MusicBrainzClient("arm-test/0.0 (test@example.com)", http_client)
     result = await client.lookup_disc_id("q")
     assert result.payload["tracks"] == [
-        {"title": "Good Track", "position": 1},
-        {"title": "Mystery Position"},
-        {"title": "Int Position", "position": 4},
+        {"title": "Good Track", "position": 1, "length_ms": None, "disc_number": 1},
+        {"title": "Mystery Position", "length_ms": None, "disc_number": 1},
+        {"title": "Int Position", "position": 4, "length_ms": None, "disc_number": 1},
     ]
 
 
@@ -957,7 +957,9 @@ async def test_get_release_success(http_client):
     assert result.year == 1973
     assert result.kind == "music"
     assert result.payload["artist"] == "Pink Floyd"
-    assert result.payload["tracks"] == [{"title": "Speak to Me", "position": 1}]
+    assert result.payload["tracks"] == [
+        {"title": "Speak to Me", "position": 1, "length_ms": None, "disc_number": 1}
+    ]
 
 
 @respx.mock
@@ -976,6 +978,65 @@ async def test_get_release_missing_title_raises(http_client):
     )
     with pytest.raises(LookupError, match="missing title"):
         await MusicBrainzClient("armv3", http_client).get_release("no-title")
+
+
+@respx.mock
+async def test_get_release_extracts_length_and_release_fields(http_client):
+    respx.get("https://musicbrainz.org/ws/2/release/mbid-2").mock(
+        return_value=httpx.Response(200, json={
+            "id": "mbid-2", "title": "Abbey Road", "date": "1969-09-26",
+            "artist-credit": [{"name": "The Beatles"}],
+            "country": "GB", "barcode": "0094638246619", "status": "Official",
+            "label-info": [{"catalog-number": "PCS 7088"}],
+            "media": [{
+                "format": "CD",
+                "tracks": [
+                    {"position": "1", "title": "Come Together", "length": 259000},
+                    {"position": "2", "title": "Something", "length": 182000},
+                ],
+            }],
+        })
+    )
+    result = await MusicBrainzClient("armv3", http_client).get_release("mbid-2")
+    p = result.payload
+    assert p["tracks"][0] == {"title": "Come Together", "position": 1, "length_ms": 259000, "disc_number": 1}
+    assert p["country"] == "GB"
+    assert p["barcode"] == "0094638246619"
+    assert p["status"] == "Official"
+    assert p["catalog_number"] == "PCS 7088"
+    assert p["format"] == "CD"
+    assert p["disc_count"] == 1
+    assert p["track_count"] == 2
+
+
+@respx.mock
+async def test_get_release_multi_disc_tags_disc_number(http_client):
+    respx.get("https://musicbrainz.org/ws/2/release/mbid-3").mock(
+        return_value=httpx.Response(200, json={
+            "id": "mbid-3", "title": "The Wall", "date": "1979",
+            "artist-credit": [{"name": "Pink Floyd"}],
+            "media": [
+                {"format": "CD", "tracks": [{"position": "1", "title": "In the Flesh?", "length": 199000}]},
+                {"format": "CD", "tracks": [{"position": "1", "title": "Hey You", "length": 280000}]},
+            ],
+        })
+    )
+    p = (await MusicBrainzClient("armv3", http_client).get_release("mbid-3")).payload
+    assert p["disc_count"] == 2
+    assert [t["disc_number"] for t in p["tracks"]] == [1, 2]
+    assert [t["title"] for t in p["tracks"]] == ["In the Flesh?", "Hey You"]
+
+
+@respx.mock
+async def test_search_releases_artist_and_track_count_in_query(http_client):
+    route = respx.get("https://musicbrainz.org/ws/2/release").mock(
+        return_value=httpx.Response(200, json={"releases": []})
+    )
+    await MusicBrainzClient("armv3", http_client).search_releases("Abbey Road", artist="The Beatles", track_count=17)
+    sent = route.calls.last.request.url.params["query"]
+    assert "Abbey Road" in sent
+    assert 'artist:"The Beatles"' in sent
+    assert "tracks:17" in sent
 
 
 # ---------------------------------------------------------------------------

--- a/services/backend/tests/test_metadata_schema_fields.py
+++ b/services/backend/tests/test_metadata_schema_fields.py
@@ -14,9 +14,15 @@ def test_release_track_fields_default_none():
 
 def test_release_detail_has_enriched_fields():
     d = MetadataReleaseDetail(
-        release_id="r1", title="Abbey Road",
-        catalog_number="PCS 7088", barcode="0094638246619", country="GB",
-        format="CD", status="Official", disc_count=1, track_count=17,
+        release_id="r1",
+        title="Abbey Road",
+        catalog_number="PCS 7088",
+        barcode="0094638246619",
+        country="GB",
+        format="CD",
+        status="Official",
+        disc_count=1,
+        track_count=17,
     )
     assert d.catalog_number == "PCS 7088"
     assert d.barcode == "0094638246619"

--- a/services/backend/tests/test_metadata_schema_fields.py
+++ b/services/backend/tests/test_metadata_schema_fields.py
@@ -1,0 +1,27 @@
+from arm_common.schemas.metadata import MetadataReleaseDetail, MetadataReleaseTrack
+
+
+def test_release_track_has_length_and_disc():
+    t = MetadataReleaseTrack(position=1, title="Come Together", length_ms=259000, disc_number=1)
+    assert t.length_ms == 259000
+    assert t.disc_number == 1
+
+
+def test_release_track_fields_default_none():
+    t = MetadataReleaseTrack(title="X")
+    assert t.length_ms is None and t.disc_number is None
+
+
+def test_release_detail_has_enriched_fields():
+    d = MetadataReleaseDetail(
+        release_id="r1", title="Abbey Road",
+        catalog_number="PCS 7088", barcode="0094638246619", country="GB",
+        format="CD", status="Official", disc_count=1, track_count=17,
+    )
+    assert d.catalog_number == "PCS 7088"
+    assert d.barcode == "0094638246619"
+    assert d.country == "GB"
+    assert d.format == "CD"
+    assert d.status == "Official"
+    assert d.disc_count == 1
+    assert d.track_count == 17

--- a/services/backend/tests/test_metadata_search_router.py
+++ b/services/backend/tests/test_metadata_search_router.py
@@ -566,9 +566,7 @@ def test_music_detail_maps_enriched_fields(signing_key: bytes) -> None:
                 "barcode": "0094638246619",
                 "status": "Official",
                 "label-info": [{"catalog-number": "PCS 7088"}],
-                "media": [
-                    {"format": "CD", "tracks": [{"position": "1", "title": "Come Together", "length": 259000}]}
-                ],
+                "media": [{"format": "CD", "tracks": [{"position": "1", "title": "Come Together", "length": 259000}]}],
             },
         )
     )

--- a/services/backend/tests/test_metadata_search_router.py
+++ b/services/backend/tests/test_metadata_search_router.py
@@ -529,3 +529,62 @@ def test_music_release_detail_unavailable_502(signing_key: bytes) -> None:
     with TestClient(app) as c:
         r = c.get("/api/metadata/music/mbid-1", headers=_auth(token))
     assert r.status_code == 502, r.text
+
+
+@respx.mock
+def test_music_search_threads_artist_and_track_count(signing_key: bytes) -> None:
+    route = respx.get("https://musicbrainz.org/ws/2/release").mock(
+        return_value=httpx.Response(200, json={"releases": []})
+    )
+    db = FakeSession()
+    _seed(db)
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get(
+            "/api/metadata/music/search",
+            params={"query": "abbey road", "artist": "the beatles", "track_count": 17},
+            headers=_auth(token),
+        )
+    assert r.status_code == 200, r.text
+    sent = route.calls.last.request.url.params["query"]
+    assert "abbey road" in sent
+    assert 'artist:"the beatles"' in sent
+    assert "tracks:17" in sent
+
+
+@respx.mock
+def test_music_detail_maps_enriched_fields(signing_key: bytes) -> None:
+    respx.get("https://musicbrainz.org/ws/2/release/mbid-9").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "mbid-9",
+                "title": "Abbey Road",
+                "date": "1969-09-26",
+                "artist-credit": [{"name": "The Beatles"}],
+                "country": "GB",
+                "barcode": "0094638246619",
+                "status": "Official",
+                "label-info": [{"catalog-number": "PCS 7088"}],
+                "media": [
+                    {"format": "CD", "tracks": [{"position": "1", "title": "Come Together", "length": 259000}]}
+                ],
+            },
+        )
+    )
+    db = FakeSession()
+    _seed(db)
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/music/mbid-9", headers=_auth(token))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["country"] == "GB"
+    assert body["barcode"] == "0094638246619"
+    assert body["status"] == "Official"
+    assert body["catalog_number"] == "PCS 7088"
+    assert body["format"] == "CD"
+    assert body["disc_count"] == 1
+    assert body["track_count"] == 1
+    assert body["tracks"][0]["length_ms"] == 259000
+    assert body["tracks"][0]["disc_number"] == 1

--- a/services/backend/tests/test_resolve_disc_fields.py
+++ b/services/backend/tests/test_resolve_disc_fields.py
@@ -1,0 +1,136 @@
+"""Verify that POST /api/jobs/{id}/resolve accepts and persists disc_number/disc_total.
+
+Mirrors the harness from test_resolve_fanout.py (FakeSession + TestClient,
+no Postgres, no Docker).
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+from pathlib import Path
+
+os.environ.setdefault("DATABASE_URL", "postgresql://x:x@localhost/x")
+os.environ.setdefault("ARM_SERVICE_TOKEN", "tok-service")
+
+import pytest  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from arm_backend.db import get_session  # noqa: E402
+from arm_backend.jwt_utils import issue_access_token  # noqa: E402
+from arm_backend.routers import jobs as jobs_router  # noqa: E402
+from arm_common import (  # noqa: E402
+    DiscType,
+    Job,
+    JobStatus,
+    User,
+)
+
+from tests._fakes import FakeSession  # noqa: E402
+
+
+@pytest.fixture
+def signing_key() -> bytes:
+    return secrets.token_bytes(32)
+
+
+class _CapturingHub:
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+
+    async def emit(
+        self,
+        topic: str,
+        event_type: str,
+        payload: dict,
+        *,
+        persist: bool = True,
+        job_id: str | None = None,
+        track_id: str | None = None,
+        session: object = None,
+    ) -> None:
+        self.events.append({"topic": topic, "event_type": event_type, "payload": payload})
+
+
+_JOB_ID = "job_01JZXR7K3M5Q8N4VWA00000002"
+
+
+def _seed_cd_job(db: FakeSession) -> Job:
+    """Seed a minimal CD job in AWAITING_USER_ID — no session/app needed for disc-field test."""
+    db.rows["users"] = [User(id="usr_admin", username="admin", password_hash="x", password_must_change=False)]
+    job = Job(
+        id=_JOB_ID,
+        drive_id="drv_cd",
+        disc_type=DiscType.CD,
+        title=None,
+        year=None,
+        disc_number=None,
+        disc_total=None,
+        status=JobStatus.AWAITING_USER_ID,
+        metadata_json={},
+        resumed_from_crash=False,
+    )
+    db.rows["jobs"] = [job]
+    db.rows["session_applications"] = []
+    db.rows["sessions"] = []
+    db.rows["rip_presets"] = []
+    db.rows["transcode_presets"] = []
+    db.rows["tracks"] = []
+    db.rows["transcode_tasks"] = []
+    db.rows["drives"] = []
+    return job
+
+
+def _make_app(signing_key: bytes, db: FakeSession, tmp_path: Path) -> tuple[FastAPI, str]:
+    from arm_backend import config as bcfg
+
+    bcfg.settings.MEDIA_ROOT = str(tmp_path)
+
+    app = FastAPI()
+    app.state.signing_key = signing_key
+    app.state.ws_hub = _CapturingHub()
+    app.include_router(jobs_router.router)
+
+    async def _override_session() -> FakeSession:
+        return db
+
+    app.dependency_overrides[get_session] = _override_session
+    token, _ = issue_access_token("usr_admin", "admin", signing_key)
+    return app, token
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_resolve_persists_disc_fields(signing_key: bytes, tmp_path: Path) -> None:
+    """A resolvable CD job + a resolve call carrying disc_number/disc_total
+    must persist them onto the job row and return them in the response."""
+    db = FakeSession()
+    _seed_cd_job(db)
+    app, token = _make_app(signing_key, db, tmp_path)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/api/jobs/{_JOB_ID}/resolve",
+            json={
+                "title": "Abbey Road",
+                "year": 1969,
+                "disc_number": 1,
+                "disc_total": 2,
+                "metadata": {"artist": "The Beatles"},
+            },
+            headers=_auth(token),
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()["job"]
+    assert body["disc_number"] == 1
+    assert body["disc_total"] == 2
+    assert body["title"] == "Abbey Road"
+
+    # Also confirm the DB row was mutated.
+    job_row = next(j for j in db.rows["jobs"] if j.id == _JOB_ID)
+    assert job_row.disc_number == 1
+    assert job_row.disc_total == 2

--- a/services/backend/tests/test_update_job_disc_fields.py
+++ b/services/backend/tests/test_update_job_disc_fields.py
@@ -1,0 +1,105 @@
+"""Verify that PATCH /api/jobs/{id} accepts and persists disc_number/disc_total.
+
+Mirrors the harness from test_jobs_router.py (FakeSession + TestClient,
+no Postgres, no Docker).
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+
+os.environ.setdefault("DATABASE_URL", "postgresql://x:x@localhost/x")
+os.environ.setdefault("ARM_SERVICE_TOKEN", "tok-service")
+
+import pytest  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from arm_backend.db import get_session  # noqa: E402
+from arm_backend.jwt_utils import issue_access_token  # noqa: E402
+from arm_backend.routers import jobs as jobs_router  # noqa: E402
+from arm_common import (  # noqa: E402
+    DiscType,
+    Job,
+    JobStatus,
+    User,
+)
+
+from tests._fakes import FakeSession  # noqa: E402
+
+
+@pytest.fixture
+def signing_key() -> bytes:
+    return secrets.token_bytes(32)
+
+
+_JOB_ID = "job_01JZXR7K3M5Q8N4VWA00000003"
+
+
+def _seed_job(db: FakeSession) -> Job:
+    """Seed a minimal CD job in RIPPED state — a terminal-ish state that update_job accepts."""
+    db.rows["users"] = [User(id="usr_admin", username="admin", password_hash="x", password_must_change=False)]
+    job = Job(
+        id=_JOB_ID,
+        drive_id="drv_cd",
+        disc_type=DiscType.CD,
+        title="Abbey Road",
+        year=1969,
+        disc_number=None,
+        disc_total=None,
+        status=JobStatus.RIPPED,
+        metadata_json={},
+        resumed_from_crash=False,
+    )
+    db.rows["jobs"] = [job]
+    db.rows["tracks"] = []
+    return job
+
+
+class _Hub:
+    async def emit(self, topic: str, event_type: str, payload: dict, **kwargs: object) -> None:
+        pass
+
+
+def _make_app(signing_key: bytes, db: FakeSession) -> tuple[FastAPI, str]:
+    app = FastAPI()
+    app.state.signing_key = signing_key
+    app.state.ws_hub = _Hub()
+    app.include_router(jobs_router.router)
+
+    async def _override_session() -> FakeSession:
+        return db
+
+    app.dependency_overrides[get_session] = _override_session
+    token, _ = issue_access_token("usr_admin", "admin", signing_key)
+    return app, token
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_patch_job_persists_disc_fields(signing_key: bytes) -> None:
+    """PATCH with disc_number/disc_total must return 200 and persist the values
+    onto the job row — confirmed in both the response body and the DB row."""
+    db = FakeSession()
+    _seed_job(db)
+    app, token = _make_app(signing_key, db)
+
+    with TestClient(app) as client:
+        resp = client.patch(
+            f"/api/jobs/{_JOB_ID}",
+            json={"disc_number": 2, "disc_total": 2},
+            headers=_auth(token),
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["disc_number"] == 2
+    assert body["disc_total"] == 2
+
+    # Also confirm the DB row was mutated.
+    job_row = next(j for j in db.rows["jobs"] if j.id == _JOB_ID)
+    assert job_row.disc_number == 2
+    assert job_row.disc_total == 2

--- a/services/ui-neu/frontend/src/lib/__tests__/jobs-api-extra.test.ts
+++ b/services/ui-neu/frontend/src/lib/__tests__/jobs-api-extra.test.ts
@@ -125,7 +125,7 @@ describe('resolveJob', () => {
 		await resolveJob('job_1', { title: 'X', year: 2020, metadata: {} });
 		expect(mockFetch).toHaveBeenCalledWith('/api/jobs/job_1/resolve', expect.objectContaining({
 			method: 'POST',
-			body: JSON.stringify({ title: 'X', year: 2020, metadata: {} })
+			body: JSON.stringify({ title: 'X', year: 2020, disc_number: null, disc_total: null, metadata: {} })
 		}));
 	});
 
@@ -134,7 +134,7 @@ describe('resolveJob', () => {
 		await resolveJob('job_2', { title: 'Album', metadata: { artist: 'A', tracks: [{ title: 'T1' }] } });
 		expect(mockFetch).toHaveBeenCalledWith('/api/jobs/job_2/resolve', expect.objectContaining({
 			method: 'POST',
-			body: JSON.stringify({ title: 'Album', year: null, metadata: { artist: 'A', tracks: [{ title: 'T1' }] } })
+			body: JSON.stringify({ title: 'Album', year: null, disc_number: null, disc_total: null, metadata: { artist: 'A', tracks: [{ title: 'T1' }] } })
 		}));
 	});
 });

--- a/services/ui-neu/frontend/src/lib/__tests__/music-api.test.ts
+++ b/services/ui-neu/frontend/src/lib/__tests__/music-api.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+function jsonResponse(data: unknown) {
+	return { ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve(data) };
+}
+import { searchMusicMetadata, resolveJob } from '../api/jobs';
+beforeEach(() => mockFetch.mockReset());
+
+describe('searchMusicMetadata', () => {
+	it('sends query only by default', async () => {
+		mockFetch.mockResolvedValue(jsonResponse({ candidates: [] }));
+		await searchMusicMetadata('abbey road');
+		const url = mockFetch.mock.calls[0][0] as string;
+		expect(url).toContain('/api/metadata/music/search?');
+		expect(url).toContain('query=abbey+road');
+		expect(url).not.toContain('artist=');
+		expect(url).not.toContain('track_count=');
+	});
+	it('adds artist + track_count when given', async () => {
+		mockFetch.mockResolvedValue(jsonResponse({ candidates: [] }));
+		await searchMusicMetadata('abbey road', { artist: 'beatles', track_count: 17 });
+		const url = mockFetch.mock.calls[0][0] as string;
+		expect(url).toContain('artist=beatles');
+		expect(url).toContain('track_count=17');
+	});
+});
+
+describe('resolveJob with disc fields', () => {
+	it('includes disc_number/disc_total in the body', async () => {
+		mockFetch.mockResolvedValue(jsonResponse({ job: {}, fan_out: [] }));
+		await resolveJob('job_1', { title: 'Abbey Road', year: 1969, disc_number: 1, disc_total: 2, metadata: { artist: 'X' } });
+		const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
+		expect(body).toEqual({ title: 'Abbey Road', year: 1969, disc_number: 1, disc_total: 2, metadata: { artist: 'X' } });
+	});
+});

--- a/services/ui-neu/frontend/src/lib/__tests__/track-match.test.ts
+++ b/services/ui-neu/frontend/src/lib/__tests__/track-match.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { matchIndicator } from '../utils/track-match';
+
+describe('matchIndicator', () => {
+	it('match when within 3s', () => {
+		expect(matchIndicator(180000, 181)).toBe('match'); // 1s diff
+		expect(matchIndicator(180000, 183)).toBe('match'); // 3s diff
+	});
+	it('close when within 10s', () => {
+		expect(matchIndicator(180000, 188)).toBe('close'); // 8s diff
+	});
+	it('mismatch beyond 10s', () => {
+		expect(matchIndicator(180000, 200)).toBe('mismatch'); // 20s diff
+	});
+	it('unknown when either side is null/undefined', () => {
+		expect(matchIndicator(null, 180)).toBe('unknown');
+		expect(matchIndicator(180000, null)).toBe('unknown');
+		expect(matchIndicator(undefined, undefined)).toBe('unknown');
+	});
+});

--- a/services/ui-neu/frontend/src/lib/api/jobs.ts
+++ b/services/ui-neu/frontend/src/lib/api/jobs.ts
@@ -122,16 +122,24 @@ export function updateJobConfig(jobId: string, data: JobUpdateRequest): Promise<
 // Identify / resolve + apply-session (EXISTS in v3)
 // ---------------------------------------------------------------------------
 
-// v3 POST /api/jobs/{id}/resolve  body: ResolveRequest { title, year?, metadata }.
+// v3 POST /api/jobs/{id}/resolve  body: ResolveRequest { title, year?, disc_number?, disc_total?, metadata }.
 // Stamps the chosen identity onto the job (status → identified). `year` defaults
-// to null and `metadata` to {} so the body always matches the v3 contract.
+// to null, disc fields to null, and `metadata` to {} so the body always matches the v3 contract.
 export function resolveJob(
 	jobId: string,
-	body: { title: string; year?: number | null; metadata?: Record<string, unknown> }
+	body: {
+		title: string;
+		year?: number | null;
+		disc_number?: number | null;
+		disc_total?: number | null;
+		metadata?: Record<string, unknown>;
+	}
 ): Promise<ResolveResponse> {
 	return post<ResolveResponse>(`/api/jobs/${jobId}/resolve`, {
 		title: body.title,
 		year: body.year ?? null,
+		disc_number: body.disc_number ?? null,
+		disc_total: body.disc_total ?? null,
 		metadata: body.metadata ?? {}
 	});
 }
@@ -175,10 +183,14 @@ export function fetchMediaDetail(imdbId: string): Promise<MetadataSearchResponse
 	return apiFetch<MetadataSearchResponse>(`/api/metadata/lookup?${params}`);
 }
 
-// v3 music search takes a single `query` param; the BFF's artist/format/country
-// filters and offset paging are gone.
-export function searchMusicMetadata(query: string): Promise<MetadataSearchResponse> {
+// v3 music search: query + optional artist + track_count (Lucene narrowing).
+export function searchMusicMetadata(
+	query: string,
+	opts?: { artist?: string; track_count?: number }
+): Promise<MetadataSearchResponse> {
 	const params = new URLSearchParams({ query });
+	if (opts?.artist) params.set('artist', opts.artist);
+	if (opts?.track_count != null) params.set('track_count', String(opts.track_count));
 	return apiFetch<MetadataSearchResponse>(`/api/metadata/music/search?${params}`);
 }
 

--- a/services/ui-neu/frontend/src/lib/components/MusicSearch.svelte
+++ b/services/ui-neu/frontend/src/lib/components/MusicSearch.svelte
@@ -107,7 +107,7 @@
 			const yr = editYear.trim() ? Number(editYear.trim()) : null;
 			const dn = discNumber.trim() ? Number(discNumber.trim()) : null;
 			const dt = discTotal.trim() ? Number(discTotal.trim()) : null;
-			const tracks = (detail.tracks ?? []).map((t) => ({
+			const tracks = visibleTracks.map((t) => ({
 				position: t.position,
 				title: t.title,
 				length_ms: t.length_ms ?? null,

--- a/services/ui-neu/frontend/src/lib/components/MusicSearch.svelte
+++ b/services/ui-neu/frontend/src/lib/components/MusicSearch.svelte
@@ -1,57 +1,70 @@
 <script lang="ts">
 	import type { JobView, TrackView, MetadataCandidate, MetadataReleaseDetail } from '$lib/types/api.gen';
-	import { searchMusicMetadata, fetchMusicDetail, updateJobTitle } from '$lib/api/jobs';
-	import { posterSrc, posterFallback } from '$lib/utils/poster';
+	import { searchMusicMetadata, fetchMusicDetail, resolveJob } from '$lib/api/jobs';
+	import { matchIndicator } from '$lib/utils/track-match';
+	import PosterImage from './PosterImage.svelte';
 
 	interface Props {
 		job: JobView;
-		// Accepted for caller compatibility; v3's music-detail contract no longer
-		// exposes per-track durations, so disc-track duration matching is gone.
-		discTracks?: TrackView[];
+		discTracks: TrackView[];
 		onapply?: () => void;
 	}
+	let { job, discTracks, onapply }: Props = $props();
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	let { job, discTracks = [], onapply }: Props = $props();
+	const meta = (job.metadata_json ?? {}) as Record<string, unknown>;
+	let query = $state(job.title || (typeof meta.album === 'string' ? meta.album : ''));
+	let artist = $state(typeof meta.artist === 'string' ? meta.artist : '');
+	let matchCount = $state(discTracks.length > 0);
 
-	let query = $state(job.title || '');
 	let searching = $state(false);
 	let results = $state<MetadataCandidate[]>([]);
 	let searchError = $state<string | null>(null);
 
-	let selectedId = $state<string | null>(null);
 	let detail = $state<MetadataReleaseDetail | null>(null);
 	let loadingDetail = $state(false);
+	let editArtist = $state('');
+	let editAlbum = $state('');
+	let editYear = $state('');
+	let discNumber = $state(job.disc_number != null ? String(job.disc_number) : '');
+	let discTotal = $state(job.disc_total != null ? String(job.disc_total) : '');
 
 	let applying = $state(false);
 	let feedback = $state<{ type: 'success' | 'error'; message: string } | null>(null);
 
-	let failedImages = $state(new Set<string>());
-
-	// Editable metadata fields (populated from detail). v3's job edit only
-	// accepts poster_url_manual; we surface the release art as the editable.
-	let editPosterUrl = $state('');
-
 	$effect(() => {
 		if (detail) {
-			editPosterUrl = detail.poster_url ?? '';
+			editArtist = detail.artist ?? '';
+			editAlbum = detail.title;
+			editYear = detail.year != null ? String(detail.year) : '';
+			if (detail.disc_count != null && detail.disc_count > 1 && !discTotal) {
+				discTotal = String(detail.disc_count);
+			}
 		}
 	});
+
+	// When the job knows its disc, scope a multi-disc release's tracklist to it.
+	let visibleTracks = $derived(
+		detail == null
+			? []
+			: detail.disc_count != null && detail.disc_count > 1 && job.disc_number != null
+				? (detail.tracks ?? []).filter((t) => t.disc_number === job.disc_number)
+				: (detail.tracks ?? [])
+	);
 
 	async function handleSearch() {
 		if (!query.trim()) return;
 		searching = true;
-		searchError = null;
 		results = [];
-		selectedId = null;
+		searchError = null;
 		detail = null;
-		failedImages = new Set();
 		try {
-			const resp = await searchMusicMetadata(query.trim());
+			const opts: { artist?: string; track_count?: number } = {};
+			if (artist.trim()) opts.artist = artist.trim();
+			if (matchCount && discTracks.length > 0) opts.track_count = discTracks.length;
+			const resp = await searchMusicMetadata(query.trim(), opts);
 			results = resp.candidates;
-			if (results.length === 0) {
-				searchError = 'No results found. Try a different search term.';
-			}
+			if (resp.detail) searchError = resp.detail;
+			else if (results.length === 0) searchError = 'No results found.';
 		} catch (e) {
 			searchError = e instanceof Error ? e.message : 'Search failed';
 		} finally {
@@ -59,251 +72,162 @@
 		}
 	}
 
-	async function handleSelect(result: MetadataCandidate) {
-		const releaseId = result.provider_id;
-		if (!releaseId) return;
-		if (selectedId === releaseId) {
-			selectedId = null;
-			detail = null;
-			return;
-		}
-		selectedId = releaseId;
+	async function openDetail(c: MetadataCandidate) {
+		if (!c.provider_id) return;
 		loadingDetail = true;
-		detail = null;
+		feedback = null;
 		try {
-			detail = await fetchMusicDetail(releaseId);
-		} catch {
-			detail = { release_id: releaseId, title: result.title, artist: null, year: result.year ?? null, poster_url: result.poster_url ?? null, tracks: [] };
+			detail = await fetchMusicDetail(c.provider_id);
+		} catch (e) {
+			feedback = { type: 'error', message: e instanceof Error ? e.message : 'Load failed' };
 		} finally {
 			loadingDetail = false;
 		}
 	}
 
-	async function applyPoster() {
+	function fmtMs(ms: number | null | undefined): string {
+		if (ms == null) return '—';
+		const total = Math.round(ms / 1000);
+		return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`;
+	}
+
+	const MATCH_GLYPH = { match: '✓', close: '~', mismatch: '✗', unknown: '—' };
+	const MATCH_CLASS = {
+		match: 'text-green-600 dark:text-green-400',
+		close: 'text-amber-600 dark:text-amber-400',
+		mismatch: 'text-red-600 dark:text-red-400',
+		unknown: 'text-gray-400'
+	};
+
+	async function applyRelease() {
+		if (!editAlbum.trim() || !detail) return;
 		applying = true;
 		feedback = null;
 		try {
-			await updateJobTitle(job.id, { poster_url_manual: editPosterUrl.trim() || null });
-			feedback = { type: 'success', message: 'Poster updated' };
+			const yr = editYear.trim() ? Number(editYear.trim()) : null;
+			const dn = discNumber.trim() ? Number(discNumber.trim()) : null;
+			const dt = discTotal.trim() ? Number(discTotal.trim()) : null;
+			const tracks = (detail.tracks ?? []).map((t) => ({
+				position: t.position,
+				title: t.title,
+				length_ms: t.length_ms ?? null,
+				disc_number: t.disc_number ?? null
+			}));
+			await resolveJob(job.id, {
+				title: editAlbum.trim(),
+				year: Number.isFinite(yr as number) ? yr : null,
+				disc_number: Number.isFinite(dn as number) ? dn : null,
+				disc_total: Number.isFinite(dt as number) ? dt : null,
+				metadata: { artist: editArtist.trim(), album: editAlbum.trim(), tracks }
+			});
+			feedback = { type: 'success', message: 'Release applied' };
 			onapply?.();
 		} catch (e) {
-			feedback = { type: 'error', message: e instanceof Error ? e.message : 'Update failed' };
+			feedback = { type: 'error', message: e instanceof Error ? e.message : 'Apply failed' };
 		} finally {
 			applying = false;
 		}
 	}
 
-	function backToResults() {
-		detail = null;
-		selectedId = null;
-	}
-
-	function handleSearchKeydown(e: KeyboardEvent) {
-		if (e.key === 'Enter') handleSearch();
-	}
-
-	function hasValidPoster(url: string | null | undefined): boolean {
-		return !!url && !failedImages.has(url);
-	}
-
-	const btnBase =
-		'rounded-lg px-3 py-1.5 text-sm font-medium disabled:opacity-50 transition-colors';
-	const inputBase =
-		'rounded-lg border border-primary/25 bg-primary/5 px-3 py-1.5 text-sm text-gray-900 focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white';
+	const inputBase = 'rounded-md border border-primary/25 bg-primary/5 px-2 py-1 text-sm text-gray-900 focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white';
+	const btnBase = 'rounded-md px-2 py-1 text-xs font-medium disabled:opacity-50 transition-colors';
 </script>
 
-<div class="space-y-4">
-	<!-- Search panel -->
-	<div class="rounded-lg border border-primary/20 bg-primary/[0.02] p-3 dark:border-primary/20 dark:bg-primary/[0.03]">
-		<div class="flex flex-wrap items-end gap-2">
-			<label class="min-w-[160px] flex-1">
-				<span class="mb-0.5 block text-[10px] font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Album / Title</span>
-				<input
-					type="text"
-					bind:value={query}
-					onkeydown={handleSearchKeydown}
-					onfocus={(e) => (e.target as HTMLInputElement).select()}
-					placeholder="Album or title..."
-					class="w-full {inputBase}"
-				/>
-			</label>
-			<div class="flex items-center gap-2">
-				<span class="mb-0.5 block text-[10px]">&nbsp;</span>
-				<button
-					onclick={handleSearch}
-					disabled={searching || !query.trim()}
-					class="{btnBase} bg-primary text-on-primary hover:bg-primary-hover dark:bg-primary dark:hover:bg-primary-hover"
-				>
-					{searching ? 'Searching...' : 'Search'}
-				</button>
-			</div>
-		</div>
+<div class="space-y-3">
+	<!-- Search form -->
+	<div class="flex flex-wrap gap-1.5">
+		<input type="text" bind:value={query} placeholder="Album / title..." class="min-w-[160px] flex-1 {inputBase}" />
+		<input type="text" bind:value={artist} placeholder="Artist (optional)" class="min-w-[120px] flex-1 {inputBase}" />
+		<button onclick={handleSearch} disabled={searching || !query.trim()} class="{btnBase} bg-primary text-on-primary hover:bg-primary-hover">
+			{searching ? '...' : 'Search'}
+		</button>
 	</div>
-
-	{#if searchError}
-		<p class="text-sm text-gray-500 dark:text-gray-400">{searchError}</p>
+	{#if discTracks.length > 0}
+		<label class="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400">
+			<input type="checkbox" bind:checked={matchCount} class="h-3.5 w-3.5" />
+			Match track count ({discTracks.length})
+		</label>
 	{/if}
 
-	<!-- Results grid (hidden when detail is shown) -->
+	{#if searchError}
+		<p class="text-xs text-gray-500 dark:text-gray-400">{searchError}</p>
+	{/if}
+
+	<!-- Results grid -->
 	{#if !detail && results.length > 0}
-		<div class="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-			{#each results as result}
-				<button
-					onclick={() => handleSelect(result)}
-					class="group flex w-full flex-col overflow-hidden rounded-lg border text-left transition-all {selectedId === result.provider_id
-						? 'border-primary ring-2 ring-primary/30'
-						: 'border-primary/20 hover:border-primary/40 dark:border-primary/20 dark:hover:border-primary/40'}"
-				>
-					<div class="relative aspect-square w-full">
-						{#if hasValidPoster(result.poster_url)}
-							<img
-								src={posterSrc(result.poster_url)}
-								alt={result.title}
-								class="aspect-square w-full object-cover"
-								loading="lazy"
-								onerror={posterFallback}
-							/>
-						{:else}
-							<div
-								class="flex aspect-square w-full items-center justify-center bg-primary/10 text-gray-400 dark:bg-primary/15"
-							>
-								<svg class="h-10 w-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-									<path
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										stroke-width="1.5"
-										d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"
-									/>
-								</svg>
-							</div>
-						{/if}
-					</div>
-					<div class="p-2">
-						<p
-							class="text-sm font-medium text-gray-900 group-hover:text-primary-text dark:text-white dark:group-hover:text-primary-text-dark line-clamp-2"
-						>
-							{result.title}
-						</p>
-						<div class="mt-1 flex flex-wrap items-center gap-1">
-							{#if result.year}
-								<span class="text-xs text-gray-500 dark:text-gray-400">{result.year}</span>
-							{/if}
-							<span class="rounded-sm bg-purple-100 px-1 py-0.5 text-[10px] font-medium text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">
-								{result.kind}
-							</span>
-						</div>
+		<div class="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+			{#each results as c}
+				<button onclick={() => openDetail(c)} class="group rounded-md border border-primary/15 text-left dark:border-primary/20">
+					<PosterImage url={c.poster_url} class="aspect-square w-full rounded-t-md object-cover" />
+					<div class="p-1.5">
+						<p class="truncate text-[11px] font-medium text-gray-900 dark:text-white">{c.title}</p>
+						{#if c.year}<p class="text-[10px] text-gray-500">{c.year}</p>{/if}
 					</div>
 				</button>
 			{/each}
 		</div>
 	{/if}
 
-	<!-- Detail panel -->
+	<!-- Detail / apply -->
 	{#if loadingDetail}
-		<div class="rounded-lg border border-primary/20 bg-page p-4 text-sm text-gray-500 dark:border-primary/20 dark:bg-page-dark dark:text-gray-400">
-			Loading details...
-		</div>
+		<p class="text-xs text-gray-400">Loading...</p>
 	{:else if detail}
-		<div class="overflow-hidden rounded-lg border border-primary/20 dark:border-primary/20">
-			<div class="space-y-3 p-4">
-				{#if results.length > 0}
-					<button
-						onclick={backToResults}
-						class="inline-flex items-center gap-1 text-sm text-primary hover:text-primary-hover dark:text-primary dark:hover:text-primary-hover"
-					>
-						<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-						</svg>
-						Back to results
-					</button>
+		<div class="space-y-3 rounded-md border border-primary/15 bg-primary/5 p-3 dark:border-primary/20 dark:bg-primary/10">
+			<button onclick={() => (detail = null)} class="{btnBase} text-gray-500 hover:text-gray-700 dark:text-gray-400">← Back to results</button>
+			<div class="flex items-start gap-3">
+				<PosterImage url={detail.poster_url} class="h-24 w-24 rounded object-cover" />
+				<div class="min-w-0 text-xs text-gray-600 dark:text-gray-400">
+					<p class="text-sm font-semibold text-gray-900 dark:text-white">{detail.title}</p>
+					<p>{detail.artist ?? ''}</p>
+					<p class="mt-1 space-x-2">
+						{#if detail.country}<span>{detail.country}</span>{/if}
+						{#if detail.format}<span>{detail.format}</span>{/if}
+						{#if detail.status}<span>{detail.status}</span>{/if}
+						{#if detail.disc_count && detail.disc_count > 1}<span>{detail.disc_count} discs</span>{/if}
+					</p>
+					<p class="mt-0.5 font-mono text-[10px]">
+						{#if detail.catalog_number}Cat# {detail.catalog_number}{/if}
+						{#if detail.barcode}· {detail.barcode}{/if}
+					</p>
+				</div>
+			</div>
+
+			<!-- Tracklist with match indicators -->
+			<div class="overflow-x-auto rounded border border-primary/15 dark:border-primary/20">
+				<table class="w-full text-left text-xs">
+					<thead class="bg-page text-gray-600 dark:bg-primary/5 dark:text-gray-400">
+						<tr><th class="px-2 py-1">#</th><th class="px-2 py-1">Title</th><th class="px-2 py-1 text-right">Length</th>{#if discTracks.length > 0}<th class="px-2 py-1 text-center">Match</th>{/if}</tr>
+					</thead>
+					<tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+						{#each visibleTracks as t, i}
+							{@const kind = matchIndicator(t.length_ms, discTracks[i]?.expected_duration_seconds)}
+							<tr>
+								<td class="px-2 py-1">{t.position ?? i + 1}</td>
+								<td class="px-2 py-1">{t.title}</td>
+								<td class="px-2 py-1 text-right">{fmtMs(t.length_ms)}</td>
+								{#if discTracks.length > 0}<td class="px-2 py-1 text-center {MATCH_CLASS[kind]}" title={kind}>{MATCH_GLYPH[kind]}</td>{/if}
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+
+			<!-- Editable fields -->
+			<div class="grid grid-cols-2 gap-2">
+				<label class="col-span-2"><span class="mb-0.5 block text-[10px] text-gray-500">Album</span><input bind:value={editAlbum} class="w-full {inputBase}" /></label>
+				<label><span class="mb-0.5 block text-[10px] text-gray-500">Artist</span><input bind:value={editArtist} class="w-full {inputBase}" /></label>
+				<label><span class="mb-0.5 block text-[10px] text-gray-500">Year</span><input bind:value={editYear} class="w-full {inputBase}" /></label>
+				<label><span class="mb-0.5 block text-[10px] text-gray-500">Disc #</span><input bind:value={discNumber} placeholder="—" class="w-full {inputBase}" /></label>
+				<label><span class="mb-0.5 block text-[10px] text-gray-500">Disc total</span><input bind:value={discTotal} placeholder="—" class="w-full {inputBase}" /></label>
+			</div>
+
+			<div class="flex items-center gap-2">
+				<button onclick={applyRelease} disabled={applying || !editAlbum.trim()} class="{btnBase} bg-green-600 text-white hover:bg-green-700 dark:bg-green-500">
+					{applying ? 'Applying...' : 'Apply'}
+				</button>
+				{#if feedback}
+					<span class="text-xs {feedback.type === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}">{feedback.message}</span>
 				{/if}
-
-				<!-- Album art + info summary -->
-				<div class="flex gap-4">
-					<div class="relative h-28 w-28 shrink-0 overflow-hidden rounded-md">
-						{#if hasValidPoster(detail.poster_url)}
-							<img
-								src={posterSrc(detail.poster_url)}
-								alt={detail.title}
-								class="h-full w-full object-cover"
-								onerror={posterFallback}
-							/>
-						{:else}
-							<div
-								class="flex h-full w-full items-center justify-center bg-primary/10 text-gray-400 dark:bg-primary/15"
-							>
-								<svg class="h-10 w-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-									<path
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										stroke-width="1.5"
-										d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"
-									/>
-								</svg>
-							</div>
-						{/if}
-					</div>
-					<div class="min-w-0 flex-1">
-						<p class="text-lg font-semibold text-gray-900 dark:text-white">{detail.title}</p>
-						{#if detail.artist}
-							<p class="text-sm text-gray-600 dark:text-gray-300">{detail.artist}</p>
-						{/if}
-						{#if detail.year}
-							<p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">{detail.year}</p>
-						{/if}
-					</div>
-				</div>
-
-				<!-- Track listing -->
-				{#if detail.tracks && detail.tracks.length > 0}
-					<div>
-						<h4 class="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-300">Track Listing</h4>
-						<div class="overflow-x-auto rounded-md border border-primary/15 dark:border-primary/20">
-							<table class="w-full text-left text-xs">
-								<thead class="bg-page text-gray-500 dark:bg-primary/5 dark:text-gray-400">
-									<tr>
-										<th class="w-10 px-3 py-1.5 font-medium">#</th>
-										<th class="px-3 py-1.5 font-medium">Title</th>
-									</tr>
-								</thead>
-								<tbody class="divide-y divide-gray-100 dark:divide-gray-700/50">
-									{#each detail.tracks as track, i}
-										<tr>
-											<td class="px-3 py-1.5 font-mono text-gray-500 dark:text-gray-400">{track.position ?? i + 1}</td>
-											<td class="px-3 py-1.5 text-gray-700 dark:text-gray-300">{track.title}</td>
-										</tr>
-									{/each}
-								</tbody>
-							</table>
-						</div>
-					</div>
-				{/if}
-
-				<!-- Editable poster -->
-				<div class="grid grid-cols-1 gap-3">
-					<label>
-						<span class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">Cover Art URL</span>
-						<input type="text" bind:value={editPosterUrl} placeholder="https://..." class="w-full {inputBase}" />
-					</label>
-				</div>
-				<div class="flex items-center gap-2">
-					<button
-						onclick={applyPoster}
-						disabled={applying}
-						class="{btnBase} bg-green-600 text-white hover:bg-green-700 dark:bg-green-500 dark:hover:bg-green-600"
-					>
-						{applying ? 'Applying...' : 'Apply Cover Art'}
-					</button>
-					{#if feedback}
-						<span
-							class="text-xs {feedback.type === 'success'
-								? 'text-green-600 dark:text-green-400'
-								: 'text-red-600 dark:text-red-400'}"
-						>
-							{feedback.message}
-						</span>
-					{/if}
-				</div>
 			</div>
 		</div>
 	{/if}

--- a/services/ui-neu/frontend/src/lib/components/MusicSearch.test.ts
+++ b/services/ui-neu/frontend/src/lib/components/MusicSearch.test.ts
@@ -1,133 +1,57 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { renderComponent, screen, fireEvent, cleanup, waitFor } from '$lib/test-utils';
 import MusicSearch from './MusicSearch.svelte';
-import { createJob } from './__fixtures__/job';
-import type { MetadataCandidate } from '$lib/types/api.gen';
+import { createJob, createTrack } from './__fixtures__/job';
 
 vi.mock('$lib/api/jobs', () => ({
 	searchMusicMetadata: vi.fn(),
 	fetchMusicDetail: vi.fn(),
-	updateJobTitle: vi.fn(() => Promise.resolve())
+	resolveJob: vi.fn(() => Promise.resolve({ job: {}, fan_out: [] }))
 }));
+import { searchMusicMetadata, fetchMusicDetail, resolveJob } from '$lib/api/jobs';
+const mockSearch = vi.mocked(searchMusicMetadata);
+const mockDetail = vi.mocked(fetchMusicDetail);
+const mockResolve = vi.mocked(resolveJob);
 
-import { searchMusicMetadata, fetchMusicDetail, updateJobTitle } from '$lib/api/jobs';
-const mockSearchMusicMetadata = vi.mocked(searchMusicMetadata);
-const mockFetchMusicDetail = vi.mocked(fetchMusicDetail);
-const mockUpdateJobTitle = vi.mocked(updateJobTitle);
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
 
-function createMusicCandidate(overrides: Partial<MetadataCandidate> = {}): MetadataCandidate {
-	return {
-		title: 'Album',
-		year: 2024,
-		kind: 'release',
-		poster_url: null,
-		provider_id: 'r1',
-		...overrides
-	};
-}
-
-describe('MusicSearch', () => {
-	afterEach(() => {
-		cleanup();
-		vi.clearAllMocks();
+it('searches with track_count when "match track count" is on and discTracks present', async () => {
+	mockSearch.mockResolvedValue({ candidates: [] });
+	renderComponent(MusicSearch, {
+		props: {
+			job: createJob({ id: 'job_1', disc_type: 'cd', title: 'Abbey Road' }),
+			discTracks: [createTrack(), createTrack({ id: 'trk_2', index: 1 })]
+		}
 	});
+	await fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+	await waitFor(() =>
+		expect(mockSearch).toHaveBeenCalledWith('Abbey Road', expect.objectContaining({ track_count: 2 }))
+	);
+});
 
-	describe('rendering', () => {
-		it('renders search form with pre-filled title', () => {
-			renderComponent(MusicSearch, {
-				props: { job: createJob({ title: 'My Album' }) }
-			});
-			expect(screen.getByDisplayValue('My Album')).toBeInTheDocument();
-		});
-
-		it('renders search button', () => {
-			renderComponent(MusicSearch, {
-				props: { job: createJob() }
-			});
-			expect(screen.getByText('Search')).toBeInTheDocument();
-		});
+it('loads detail and applies the chosen release via resolveJob', async () => {
+	mockSearch.mockResolvedValue({
+		candidates: [{ title: 'Abbey Road', year: 1969, kind: 'music', poster_url: null, provider_id: 'rel-1' }]
 	});
-
-	describe('interactions', () => {
-		it('calls searchMusicMetadata with query only', async () => {
-			mockSearchMusicMetadata.mockResolvedValue({
-				candidates: [createMusicCandidate({ title: 'Found Album' })]
-			});
-			renderComponent(MusicSearch, {
-				props: { job: createJob({ title: 'Search Term' }) }
-			});
-			await fireEvent.click(screen.getByText('Search'));
-			await waitFor(() => {
-				expect(mockSearchMusicMetadata).toHaveBeenCalledWith('Search Term');
-				expect(screen.getByText('Found Album')).toBeInTheDocument();
-			});
-		});
-
-		it('shows no results message', async () => {
-			mockSearchMusicMetadata.mockResolvedValue({ candidates: [] });
-			renderComponent(MusicSearch, {
-				props: { job: createJob({ title: 'Nothing' }) }
-			});
-			await fireEvent.click(screen.getByText('Search'));
-			await waitFor(() => {
-				expect(screen.getByText(/No results found/)).toBeInTheDocument();
-			});
-		});
-
-		it('shows error on search failure', async () => {
-			mockSearchMusicMetadata.mockRejectedValue(new Error('MusicBrainz error'));
-			renderComponent(MusicSearch, {
-				props: { job: createJob({ title: 'Test' }) }
-			});
-			await fireEvent.click(screen.getByText('Search'));
-			await waitFor(() => {
-				expect(screen.getByText('MusicBrainz error')).toBeInTheDocument();
-			});
-		});
-
-		it('renders result cards with year', async () => {
-			mockSearchMusicMetadata.mockResolvedValue({
-				candidates: [
-					createMusicCandidate({ provider_id: 'r1', title: 'Album One' }),
-					createMusicCandidate({ provider_id: 'r2', title: 'Album Two', year: 2023 })
-				]
-			});
-			renderComponent(MusicSearch, {
-				props: { job: createJob({ title: 'Test' }) }
-			});
-			await fireEvent.click(screen.getByText('Search'));
-			await waitFor(() => {
-				expect(screen.getByText('Album One')).toBeInTheDocument();
-				expect(screen.getByText('Album Two')).toBeInTheDocument();
-			});
-		});
-
-		it('loads release detail and applies cover art via updateJobTitle', async () => {
-			mockSearchMusicMetadata.mockResolvedValue({
-				candidates: [createMusicCandidate({ provider_id: 'r9', title: 'Album One', poster_url: 'https://img/a.jpg' })]
-			});
-			mockFetchMusicDetail.mockResolvedValue({
-				release_id: 'r9',
-				title: 'Album One',
-				artist: 'Band A',
-				year: 2024,
-				poster_url: 'https://img/a.jpg',
-				tracks: [{ position: 1, title: 'Song 1' }]
-			});
-			renderComponent(MusicSearch, {
-				props: { job: createJob({ id: 'job_77', title: 'Test' }) }
-			});
-			await fireEvent.click(screen.getByText('Search'));
-			await waitFor(() => expect(screen.getByText('Album One')).toBeInTheDocument());
-			await fireEvent.click(screen.getByText('Album One'));
-			await waitFor(() => {
-				expect(mockFetchMusicDetail).toHaveBeenCalledWith('r9');
-				expect(screen.getByText('Song 1')).toBeInTheDocument();
-			});
-			await fireEvent.click(screen.getByText('Apply Cover Art'));
-			await waitFor(() => {
-				expect(mockUpdateJobTitle).toHaveBeenCalledWith('job_77', { poster_url_manual: 'https://img/a.jpg' });
-			});
-		});
+	mockDetail.mockResolvedValue({
+		release_id: 'rel-1', title: 'Abbey Road', artist: 'The Beatles', year: 1969,
+		poster_url: null, disc_count: 1, track_count: 1,
+		tracks: [{ position: 1, title: 'Come Together', length_ms: 259000, disc_number: 1 }]
+	});
+	const onapply = vi.fn();
+	renderComponent(MusicSearch, {
+		props: { job: createJob({ id: 'job_9', disc_type: 'cd', title: 'Abbey Road' }), discTracks: [], onapply }
+	});
+	await fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+	await waitFor(() => screen.getByText('Abbey Road'));
+	await fireEvent.click(screen.getByText('Abbey Road'));
+	await waitFor(() => screen.getByText('Come Together'));
+	await fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+	await waitFor(() => {
+		expect(mockResolve).toHaveBeenCalledWith('job_9', expect.objectContaining({
+			title: 'Abbey Road',
+			metadata: expect.objectContaining({ artist: 'The Beatles', album: 'Abbey Road' })
+		}));
+		expect(onapply).toHaveBeenCalled();
 	});
 });

--- a/services/ui-neu/frontend/src/lib/components/MusicSearch.test.ts
+++ b/services/ui-neu/frontend/src/lib/components/MusicSearch.test.ts
@@ -29,6 +29,45 @@ it('searches with track_count when "match track count" is on and discTracks pres
 	);
 });
 
+it('multi-disc apply writes only the held disc\'s tracks', async () => {
+	mockSearch.mockResolvedValue({
+		candidates: [{ title: 'The Wall', year: 1979, kind: 'music', poster_url: null, provider_id: 'rel-2' }]
+	});
+	mockDetail.mockResolvedValue({
+		release_id: 'rel-2', title: 'The Wall', artist: 'Pink Floyd', year: 1979,
+		poster_url: null, disc_count: 2, track_count: 4,
+		tracks: [
+			{ position: 1, title: 'In the Flesh?', length_ms: 213000, disc_number: 1 },
+			{ position: 2, title: 'The Thin Ice', length_ms: 151000, disc_number: 1 },
+			{ position: 1, title: 'Hey You', length_ms: 280000, disc_number: 2 },
+			{ position: 2, title: 'Is There Anybody Out There?', length_ms: 152000, disc_number: 2 }
+		]
+	});
+	const onapply = vi.fn();
+	renderComponent(MusicSearch, {
+		props: {
+			job: createJob({ id: 'job_wall', disc_type: 'cd', title: 'The Wall', disc_number: 2 }),
+			discTracks: [
+				createTrack({ id: 'trk_d2_1', index: 0 }),
+				createTrack({ id: 'trk_d2_2', index: 1 })
+			],
+			onapply
+		}
+	});
+	await fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+	await waitFor(() => screen.getByText('The Wall'));
+	await fireEvent.click(screen.getByText('The Wall'));
+	await waitFor(() => screen.getByText('Hey You'));
+	await fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+	await waitFor(() => {
+		const [, payload] = mockResolve.mock.calls[0] as unknown as [string, { metadata: { tracks: Array<{ title: string; disc_number: number | null }> } }];
+		const titles = payload.metadata.tracks.map((t) => t.title);
+		expect(titles).toEqual(['Hey You', 'Is There Anybody Out There?']);
+		expect(titles).not.toContain('In the Flesh?');
+		expect(onapply).toHaveBeenCalled();
+	});
+});
+
 it('loads detail and applies the chosen release via resolveJob', async () => {
 	mockSearch.mockResolvedValue({
 		candidates: [{ title: 'Abbey Road', year: 1969, kind: 'music', poster_url: null, provider_id: 'rel-1' }]

--- a/services/ui-neu/frontend/src/lib/types/api.gen.ts
+++ b/services/ui-neu/frontend/src/lib/types/api.gen.ts
@@ -954,6 +954,14 @@ export type Job = {
      */
     year: number | null;
     /**
+     * Disc Number
+     */
+    disc_number: number | null;
+    /**
+     * Disc Total
+     */
+    disc_total: number | null;
+    /**
      * Poster Url
      */
     poster_url: string | null;
@@ -1043,8 +1051,8 @@ export type JobStatus = 'created' | 'awaiting_user_id' | 'identified' | 'ripping
 /**
  * JobUpdateRequest
  *
- * PATCH /api/jobs/{id} body. `poster_url_manual` edits the job; `tracks`
- * applies per-track operator edits in the same atomic save. The JOB's
+ * PATCH /api/jobs/{id} body. `poster_url_manual` + disc fields edit the job;
+ * `tracks` applies per-track operator edits in the same atomic save. The JOB's
  * title/year still live behind identify/resolve.
  */
 export type JobUpdateRequest = {
@@ -1052,6 +1060,14 @@ export type JobUpdateRequest = {
      * Poster Url Manual
      */
     poster_url_manual?: string | null;
+    /**
+     * Disc Number
+     */
+    disc_number?: number | null;
+    /**
+     * Disc Total
+     */
+    disc_total?: number | null;
     /**
      * Tracks
      */
@@ -1080,6 +1096,14 @@ export type JobView = {
      * Year
      */
     year: number | null;
+    /**
+     * Disc Number
+     */
+    disc_number?: number | null;
+    /**
+     * Disc Total
+     */
+    disc_total?: number | null;
     /**
      * Poster Url
      */
@@ -1308,6 +1332,34 @@ export type MetadataReleaseDetail = {
      */
     poster_url?: string | null;
     /**
+     * Catalog Number
+     */
+    catalog_number?: string | null;
+    /**
+     * Barcode
+     */
+    barcode?: string | null;
+    /**
+     * Country
+     */
+    country?: string | null;
+    /**
+     * Format
+     */
+    format?: string | null;
+    /**
+     * Status
+     */
+    status?: string | null;
+    /**
+     * Disc Count
+     */
+    disc_count?: number | null;
+    /**
+     * Track Count
+     */
+    track_count?: number | null;
+    /**
      * Tracks
      */
     tracks?: Array<MetadataReleaseTrack>;
@@ -1325,6 +1377,14 @@ export type MetadataReleaseTrack = {
      * Title
      */
     title: string;
+    /**
+     * Length Ms
+     */
+    length_ms?: number | null;
+    /**
+     * Disc Number
+     */
+    disc_number?: number | null;
 };
 
 /**
@@ -1949,6 +2009,14 @@ export type ResolveRequest = {
      * Year
      */
     year?: number | null;
+    /**
+     * Disc Number
+     */
+    disc_number?: number | null;
+    /**
+     * Disc Total
+     */
+    disc_total?: number | null;
     /**
      * Metadata
      */
@@ -5218,6 +5286,14 @@ export type SearchMusicApiMetadataMusicSearchGetData = {
          * Query
          */
         query: string;
+        /**
+         * Artist
+         */
+        artist?: string | null;
+        /**
+         * Track Count
+         */
+        track_count?: number | null;
     };
     url: '/api/metadata/music/search';
 };

--- a/services/ui-neu/frontend/src/lib/utils/track-match.ts
+++ b/services/ui-neu/frontend/src/lib/utils/track-match.ts
@@ -1,0 +1,14 @@
+export type MatchKind = 'match' | 'close' | 'mismatch' | 'unknown';
+
+// Compare a MusicBrainz track length (ms) to a disc track's scanned length (s).
+// ≤3s → match, ≤10s → close, else mismatch; null/undefined either side → unknown.
+export function matchIndicator(
+	releaseLenMs: number | null | undefined,
+	discLenSec: number | null | undefined
+): MatchKind {
+	if (releaseLenMs == null || discLenSec == null) return 'unknown';
+	const diff = Math.abs(releaseLenMs / 1000 - discLenSec);
+	if (diff <= 3) return 'match';
+	if (diff <= 10) return 'close';
+	return 'mismatch';
+}

--- a/services/ui-neu/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/services/ui-neu/frontend/src/routes/jobs/[id]/+page.svelte
@@ -10,6 +10,7 @@
 	import StatusBadge from '$lib/components/StatusBadge.svelte';
 	import TitleSearch from '$lib/components/TitleSearch.svelte';
 	import TrackTitleSearch from '$lib/components/TrackTitleSearch.svelte';
+	import MusicSearch from '$lib/components/MusicSearch.svelte';
 	import IdentifyDialog from '$lib/components/IdentifyDialog.svelte';
 	import ApplySessionDialog from '$lib/components/ApplySessionDialog.svelte';
 	import JobLifecycle from '$lib/components/JobLifecycle.svelte';
@@ -81,6 +82,8 @@
 		detail?.job.disc_type === 'dvd' || detail?.job.disc_type === 'bluray'
 	);
 
+	let isCdDisc = $derived(detail?.job.disc_type === 'cd');
+
 	let metadataFields = $derived(detail ? buildMetadataFields(detail.job) : []);
 
 	const panelTabBase = 'flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15';
@@ -122,6 +125,11 @@
 	}
 
 	function handleTitleApply() {
+		activePanel = null;
+		loadJob();
+	}
+
+	function handleMusicApply() {
 		activePanel = null;
 		loadJob();
 	}
@@ -259,12 +267,21 @@
 				<div class="flex border-t border-primary/15 bg-surface/50 dark:border-primary/15 dark:bg-surface-dark/50">
 					<button onclick={() => (activePanel = activePanel === 'title' ? null : 'title')} class={panelTabClass('title', true)}>Poster &amp; metadata search</button>
 				</div>
+			{:else if isCdDisc}
+				<div class="flex border-t border-primary/15 bg-surface/50 dark:border-primary/15 dark:bg-surface-dark/50">
+					<button onclick={() => (activePanel = activePanel === 'music' ? null : 'music')} class={panelTabClass('music', true)}>Match CD</button>
+				</div>
 			{/if}
 
 			<!-- Active panel content -->
 			{#if activePanel === 'title'}
 				<div class="border-t border-primary/15 p-5 dark:border-primary/15">
 					<TitleSearch {job} onapply={handleTitleApply} />
+				</div>
+			{/if}
+			{#if activePanel === 'music'}
+				<div class="border-t border-primary/15 p-5 dark:border-primary/15">
+					<MusicSearch {job} discTracks={tracks} onapply={handleMusicApply} />
 				</div>
 			{/if}
 		</div>

--- a/services/ui-neu/frontend/src/routes/jobs/[id]/page.test.ts
+++ b/services/ui-neu/frontend/src/routes/jobs/[id]/page.test.ts
@@ -35,7 +35,9 @@ vi.mock('$lib/api/jobs', () => ({
 	resolveJob: vi.fn(() => Promise.resolve({ job: createJob({ id: 'job_42' }), fan_out: [] })),
 	applySession: vi.fn(() =>
 		Promise.resolve({ session_application: {}, tasks: [], collisions: [], idempotent: false })
-	)
+	),
+	searchMusicMetadata: vi.fn(() => Promise.resolve({ candidates: [] })),
+	fetchMusicDetail: vi.fn(() => Promise.resolve({}))
 }));
 
 vi.mock('$lib/api/sessions', () => ({
@@ -123,5 +125,25 @@ describe('Job detail page (v3)', () => {
 		await waitFor(() => {
 			expect(screen.getByTestId('apply-session-select')).toBeInTheDocument();
 		});
+	});
+
+	it('shows the Match CD tab only for cd jobs', async () => {
+		mockFetchJob.mockResolvedValueOnce({
+			job: createJob({ id: 'job_cd', disc_type: 'cd', status: 'ripped', title: 'Abbey Road' }),
+			tracks: [],
+			fingerprints: []
+		});
+		renderComponent(Page);
+		await waitFor(() =>
+			expect(screen.getByRole('button', { name: 'Match CD' })).toBeInTheDocument()
+		);
+	});
+
+	it('does not show the Match CD tab for video jobs', async () => {
+		renderComponent(Page);
+		await waitFor(() => {
+			expect(screen.getByRole('heading', { name: 'Test Movie' })).toBeInTheDocument();
+		});
+		expect(screen.queryByRole('button', { name: 'Match CD' })).not.toBeInTheDocument();
 	});
 });

--- a/services/ui/openapi.snapshot.json
+++ b/services/ui/openapi.snapshot.json
@@ -4036,6 +4036,38 @@
             }
           },
           {
+            "name": "artist",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Artist"
+            }
+          },
+          {
+            "name": "track_count",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Track Count"
+            }
+          },
+          {
             "name": "authorization",
             "in": "header",
             "required": false,
@@ -8057,6 +8089,28 @@
             ],
             "title": "Year"
           },
+          "disc_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Disc Number"
+          },
+          "disc_total": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Disc Total"
+          },
           "poster_url": {
             "anyOf": [
               {
@@ -8145,6 +8199,8 @@
           "drive_id",
           "disc_type",
           "year",
+          "disc_number",
+          "disc_total",
           "poster_url",
           "poster_url_manual",
           "status",
@@ -8243,6 +8299,28 @@
             ],
             "title": "Poster Url Manual"
           },
+          "disc_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Disc Number"
+          },
+          "disc_total": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Disc Total"
+          },
           "tracks": {
             "anyOf": [
               {
@@ -8261,7 +8339,7 @@
         "additionalProperties": false,
         "type": "object",
         "title": "JobUpdateRequest",
-        "description": "PATCH /api/jobs/{id} body. `poster_url_manual` edits the job; `tracks`\napplies per-track operator edits in the same atomic save. The JOB's\ntitle/year still live behind identify/resolve."
+        "description": "PATCH /api/jobs/{id} body. `poster_url_manual` + disc fields edit the job;\n`tracks` applies per-track operator edits in the same atomic save. The JOB's\ntitle/year still live behind identify/resolve."
       },
       "JobView": {
         "properties": {
@@ -8300,6 +8378,28 @@
               }
             ],
             "title": "Year"
+          },
+          "disc_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Disc Number"
+          },
+          "disc_total": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Disc Total"
           },
           "poster_url": {
             "anyOf": [
@@ -8691,6 +8791,83 @@
             ],
             "title": "Poster Url"
           },
+          "catalog_number": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Catalog Number"
+          },
+          "barcode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Barcode"
+          },
+          "country": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Country"
+          },
+          "format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Format"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "disc_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Disc Count"
+          },
+          "track_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Track Count"
+          },
           "tracks": {
             "items": {
               "$ref": "#/components/schemas/MetadataReleaseTrack"
@@ -8722,6 +8899,28 @@
           "title": {
             "type": "string",
             "title": "Title"
+          },
+          "length_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Length Ms"
+          },
+          "disc_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Disc Number"
           }
         },
         "type": "object",
@@ -9800,6 +9999,28 @@
               }
             ],
             "title": "Year"
+          },
+          "disc_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Disc Number"
+          },
+          "disc_total": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Disc Total"
           },
           "metadata": {
             "additionalProperties": true,


### PR DESCRIPTION
Adds a CD identification UX to ui-neu, enriches the MusicBrainz backend, and makes multi-disc CD sets first-class on `Job`. Bases on `feat/community-keydb` (the disc migration chains off that branch's `0021`).

## Frontend (ui-neu)
- **Match CD panel** on the job detail page, gated to `disc_type === 'cd'` (sibling of the video metadata-search tab).
- `MusicSearch.svelte`: query + artist search with a **"match track count"** filter → results grid → release detail with a **duration-matched tracklist** (✓ ≤3s / ~ ≤10s / ✗ / — comparing release `length_ms` to the disc's scanned `expected_duration_seconds`) → editable artist/album/year/disc fields → **Apply**.
- `matchIndicator` util; `searchMusicMetadata(query, {artist, track_count})` + `resolveJob` disc fields in the API client.

## Backend (arm_common + services/backend)
- **`Job.disc_number` / `disc_total`** (migration `0022_job_disc_number`, chained off `0021_community_keydb_fields`). Persisted via both `POST /resolve` and `PATCH /api/jobs/{id}`.
- **MusicBrainz client enrich**: per-track `length_ms` + `disc_number` (extracted across **all** media for multi-disc releases), release-level `country`/`barcode`/`status`/`catalog_number`/`format`/`disc_count`/`track_count`; `search_releases` gains `artist` + `track_count` Lucene filters. Clean break — every `_extract_tracks`/`_pick_medium_for_disc` call site updated; scan-time `lookup_disc_id` now stores durations + disc numbers too.
- `/api/metadata/music/{search,release}` thread the filters + return the enriched detail. OpenAPI snapshot + ui-neu types regenerated.

## Apply model
Apply writes `job.metadata_json` (artist/album/tracks with `length_ms`/`disc_number`) + sets title/year/disc fields via `resolve`. **No Track-row sync** — v3 stores CD song titles in `metadata_json` (transcode reads them there); creating Track titles would be a dual source of truth.

## Multi-disc
Release detail filters its tracklist to the job's `disc_number` when `disc_count > 1`; **apply writes only the held disc's tracks** (the transcoder maps titles by flat index, so writing all discs would mislabel — caught in whole-branch review and fixed).

## Verification
- Backend `pytest`: 1391 passed. ui-neu `npm run check`: 0 errors; vitest: 1008 passed. OpenAPI: zero drift.
- **Live local verify**: fresh-DB migration chain `0020 → 0021_community_keydb_fields → 0022_job_disc_number` applies clean (both features' columns coexist); drove the full UI flow against live MusicBrainz — searched Abbey Road, applied the 1983 Beatles release, confirmed `metadata_json` persisted 17 tracks with `length_ms`/`disc_number` + status promoted to `identified`.

## Note on base
Functionally depends on `feat/community-keydb` (the migration chains off its `0021`). Merge that first, or merge as a unit; retarget to `main`/Tier-14 if the stack reorders.

## Related PRs
This branch **bundles the MusicBrainz User-Agent fix from #24** (cherry-picked — the live music-search flow needs the compliant UA). The change is identical to #24's; whichever merges first, the other de-dupes. Functionally this PR is self-contained and does not require #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)