### PR TITLE
fix(transcode): add libmfx-gen1.2 so QSV works on Gen12+ Intel iGPUs

### DIFF
--- a/docs/transcode-qsv-onevpl-gen12.md
+++ b/docs/transcode-qsv-onevpl-gen12.md
@@ -1,0 +1,45 @@
+# Intel QSV transcode on Gen12+ iGPUs needs the oneVPL GPU runtime
+
+## Symptom
+
+On a Gen12+ Intel iGPU (Alder Lake / N-series; e.g. the N97, iHD driver 23.x)
+every QSV transcode fails immediately. HandBrake selects the QSV encoder, reaches
+encoder init, then dies:
+
+```
+[…] encavcodecInit: H.264 (Intel Quick Sync Video)
+[QSV @ …] Error setting child device handle: -17
+ERROR: hwaccel: failed to create hwdevice
+ERROR: Failure to initialise thread 'FFMPEG encoder (libavcodec)'
+[…] libhb: work result = 3
+Encode failed (error 3).
+```
+
+The task ends `rc=3`, and (with `hw_preference=any`) the job falls back to a CPU
+software encode — which on small fanless Intel boxes can peg all cores for hours.
+
+## Root cause
+
+The transcode image shipped the oneVPL **dispatcher** (`libvpl2`) and the
+**legacy** Intel Media SDK GPU runtime (`libmfxhw64.so`), but **not** the modern
+oneVPL **GPU runtime** (`libmfx-gen`). On Gen12+ silicon the legacy Media SDK is
+deprecated/unsupported, so oneVPL falls back to it and fails with the `-17`
+child-device-handle error.
+
+It is **not** a device or permission problem: the render node is passed into the
+container, the iHD driver loads, and `vainfo` reports `VAProfileH264High :
+VAEntrypointEncSlice` (VA-API h264 encode is available). The sole missing piece
+is the GPU-side oneVPL runtime package.
+
+## Fix
+
+Install `libmfx-gen1.2` (Intel oneVPL GPU Runtime) alongside `libvpl2` in the
+transcode image (`services/transcode/Dockerfile`). With it present, oneVPL
+dispatches to the modern runtime and QSV hardware encode succeeds.
+
+## Verification
+
+On an Intel N97, after adding the package, `HandBrakeCLI … -e qsv_h264` produces
+`encavcodecInit: H.264 (Intel Quick Sync Video)` → `libhb: work result = 0` →
+`Encode done!` with output written, and a full rip→transcode→completed run lands
+the finished `.mkv` in the media root. No `-17`, no rc=3, no CPU fallback.

--- a/services/transcode/Dockerfile
+++ b/services/transcode/Dockerfile
@@ -78,7 +78,11 @@ ENV DEBIAN_FRONTEND=noninteractive \
 #   - mesa-va-drivers           — AMD (VAAPI/VCN).
 #   - intel-media-va-driver-non-free + i965-va-driver — Intel QSV (modern +
 #     legacy iGPUs). The newer driver lives in Debian `non-free`.
-#   - libvpl2                   — oneVPL runtime for Intel QSV.
+#   - libvpl2 + libmfx-gen1.2   — oneVPL dispatcher (libvpl2) AND the modern
+#     oneVPL GPU runtime (libmfx-gen). The GPU runtime is REQUIRED on Gen12+
+#     Intel (Alder Lake / N-series, iHD 23.x): without it, oneVPL falls back to
+#     the legacy Media SDK (libmfxhw64) which dies with "Error setting child
+#     device handle: -17" → rc=3 on that silicon. Verified on an N97.
 # We apt-install `handbrake-cli` for its full runtime dependency closure, then
 # (further down) overwrite the binary with our HW-enabled build from the builder
 # stage. NVENC needs nothing baked here: `libnvidia-encode` is injected at
@@ -107,6 +111,7 @@ RUN echo 'deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://
         intel-media-va-driver-non-free \
         i965-va-driver \
         libvpl2 \
+        libmfx-gen1.2 \
     && rm -rf /var/lib/apt/lists/*
 
 # Replace Debian's HW-less HandBrakeCLI with the HW-enabled build (NVENC/QSV/VCE).


### PR DESCRIPTION
## Problem

On Gen12+ Intel iGPUs (Alder Lake / N-series; e.g. N97, iHD driver 23.x) every
QSV transcode fails immediately:

```
encavcodecInit: H.264 (Intel Quick Sync Video)
[QSV] Error setting child device handle: -17
ERROR: hwaccel: failed to create hwdevice
libhb: work result = 3 → Encode failed (error 3).
```

The task ends `rc=3`. With `hw_preference=any` the job then falls back to a CPU
software encode — which on small fanless Intel boxes can peg every core for hours.

## Root cause

The transcode image ships the oneVPL **dispatcher** (`libvpl2`) and the **legacy**
Intel Media SDK GPU runtime (`libmfxhw64`), but **not** the modern oneVPL **GPU
runtime** (`libmfx-gen`). On Gen12+ silicon the legacy Media SDK is deprecated, so
oneVPL falls back to it and fails with the `-17` child-device-handle error.

Not a device/permission issue: the render node is passed in, the iHD driver loads,
and `vainfo` reports `VAProfileH264High : VAEntrypointEncSlice` (VA-API h264 encode
is available). The only missing piece is the GPU-side oneVPL runtime.

## Fix

Add `libmfx-gen1.2` (Intel oneVPL GPU Runtime) to `services/transcode/Dockerfile`.
oneVPL then dispatches to the modern runtime and QSV hardware encode succeeds.

## Verification (Intel N97)

`HandBrakeCLI … -e qsv_h264` → `encavcodecInit: H.264 (Intel Quick Sync Video)` →
`libhb: work result = 0` → `Encode done!`. A full rip → apply h264 GPU session →
transcode → completed run produced the finished `.mkv` in the media root, on the
GPU, no `-17`, no rc=3, no CPU fallback.

Adds `docs/transcode-qsv-onevpl-gen12.md` documenting the symptom/cause/fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)