### PR TITLE
feat: Tier-21 — scanned-titles preview (ui-neu)

### DIFF
--- a/services/ui-neu/frontend/src/lib/components/DiscReviewWidget.svelte
+++ b/services/ui-neu/frontend/src/lib/components/DiscReviewWidget.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import type { JobView, JobDetailView, TrackView } from '$lib/types/api.gen';
+	import type { JobView, JobDetailView, TrackView, ScanResult } from '$lib/types/api.gen';
 	import { abandonJob, fetchJob, startWaitingJob, pauseWaitingJob, resolveJob } from '$lib/api/jobs';
 	import CountdownTimer from './CountdownTimer.svelte';
 	import { discTypeLabel } from '$lib/utils/job-type';
@@ -45,6 +45,9 @@
 	let errorMessage = $state<string | null>(null);
 
 	let tracks = $derived<TrackView[]>(data?.tracks ?? []);
+	let scanTitles = $derived(
+		((data?.job?.metadata_json?.scan_result as ScanResult | undefined)?.titles) ?? []
+	);
 
 	// v3 classifies disc kind via disc_type. cd → music, data → data, the rest
 	// are video.
@@ -275,7 +278,7 @@
 		{#if initialLoading}
 			<p class="p-4 text-sm text-gray-400">Loading...</p>
 		{:else}
-			<ReviewTracksTable {job} {tracks} {isVideo} {isMusic} onrefresh={() => { onrefresh?.(); loadDetail(); }} />
+			<ReviewTracksTable {job} {tracks} {scanTitles} {isVideo} {isMusic} onrefresh={() => { onrefresh?.(); loadDetail(); }} />
 		{/if}
 	</div>
 

--- a/services/ui-neu/frontend/src/lib/components/DiscReviewWidget.test.ts
+++ b/services/ui-neu/frontend/src/lib/components/DiscReviewWidget.test.ts
@@ -250,4 +250,27 @@ describe('DiscReviewWidget', () => {
 		const { container } = renderComponent(DiscReviewWidget, { props: {} });
 		expect(container.querySelector('[aria-busy="true"]')).not.toBeNull();
 	});
+
+	it('renders scanned titles when the job has no materialized tracks yet', async () => {
+		const { fetchJob } = await import('$lib/api/jobs');
+		vi.mocked(fetchJob).mockResolvedValueOnce(
+			detail(
+				{
+					status: 'awaiting_user_id',
+					metadata_json: {
+						scan_result: {
+							disc_type: 'dvd',
+							titles: [
+								{ index: 0, duration_seconds: 3600, source_file: 'B1_t00.mkv' },
+								{ index: 1, duration_seconds: 1800, source_file: 'B1_t01.mkv' }
+							]
+						}
+					}
+				},
+				[]
+			)
+		);
+		renderWidget({ status: 'awaiting_user_id' });
+		await waitFor(() => expect(screen.getByText('Scanned titles (2)')).toBeInTheDocument());
+	});
 });

--- a/services/ui-neu/frontend/src/lib/components/ReviewTracksTable.svelte
+++ b/services/ui-neu/frontend/src/lib/components/ReviewTracksTable.svelte
@@ -1,16 +1,21 @@
 <script lang="ts">
-	import type { JobView, TrackView } from '$lib/types/api.gen';
+	import type { JobView, TrackView, ScanTitle } from '$lib/types/api.gen';
 	import { updateTrack } from '$lib/api/jobs';
+	import { trackToRow, scanTitleToRow } from '$lib/utils/review-rows';
 	import TrackTitleSearch from './TrackTitleSearch.svelte';
 
 	interface Props {
 		job: JobView;
 		tracks: TrackView[];
+		scanTitles?: ScanTitle[];
 		isVideo: boolean;
 		isMusic: boolean;
 		onrefresh?: () => void;
 	}
-	let { job, tracks, isVideo, isMusic, onrefresh }: Props = $props();
+	let { job, tracks, scanTitles = [], isVideo, isMusic, onrefresh }: Props = $props();
+
+	// Materialized tracks always win; scanned titles are the pre-rip fallback.
+	let rows = $derived(tracks.length ? tracks.map(trackToRow) : scanTitles.map(scanTitleToRow));
 
 	let openSearchTrackIds = $state<Set<string>>(new Set());
 	let savingTrackField = $state<string | null>(null);
@@ -69,9 +74,11 @@
 	{#if errorMessage}
 		<p class="mb-2 text-xs text-red-600 dark:text-red-400">{errorMessage}</p>
 	{/if}
-	{#if tracks.length > 0}
+	{#if rows.length > 0}
 		<div>
-			<h4 class="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-300">Tracks ({tracks.length})</h4>
+			<h4 class="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-300">
+				{tracks.length ? 'Tracks' : 'Scanned titles'} ({rows.length})
+			</h4>
 			<div class="overflow-x-auto rounded-md border border-primary/15 dark:border-primary/20">
 				<table class="w-full text-left text-xs">
 					<thead class="bg-page text-gray-500 dark:bg-primary/5 dark:text-gray-400">
@@ -85,56 +92,64 @@
 						</tr>
 					</thead>
 					<tbody class="divide-y divide-gray-100 dark:divide-gray-700/50">
-						{#each tracks as track}
-							<tr class="{track.excluded ? 'opacity-40' : ''}">
-								<td class="px-3 py-1.5 font-mono text-gray-700 dark:text-gray-300">{track.index}</td>
+						{#each rows as row}
+							<tr class="{row.excluded ? 'opacity-40' : ''}">
+								<td class="px-3 py-1.5 font-mono text-gray-700 dark:text-gray-300">{row.index}</td>
 								<td
-									class="px-3 py-1.5 {isVideo ? 'cursor-pointer hover:bg-primary/5 dark:hover:bg-primary/10' : ''}"
-									onclick={() => { if (isVideo) toggleTrackSearch(track.id); }}
+									class="px-3 py-1.5 {isVideo && row.trackId ? 'cursor-pointer hover:bg-primary/5 dark:hover:bg-primary/10' : ''}"
+									onclick={() => { if (isVideo && row.trackId) toggleTrackSearch(row.trackId!); }}
 								>
-									{#if track.title}
+									{#if row.title}
 										<div class="flex items-center gap-1.5">
-											<span class="font-medium text-gray-700 dark:text-gray-300">{track.title}</span>
-											{#if track.year}
-												<span class="text-gray-400">({track.year})</span>
+											<span class="font-medium text-gray-700 dark:text-gray-300">{row.title}</span>
+											{#if row.year}
+												<span class="text-gray-400">({row.year})</span>
 											{/if}
 										</div>
-									{:else}
+									{:else if row.trackId}
 										<span class="text-gray-400">{job.title || 'Untitled'}{#if job.year} ({job.year}){/if}</span>
+									{:else}
+										<span class="text-gray-400">—</span>
 									{/if}
 								</td>
 								{#if isVideo}
 									<td class="px-2 py-1.5 text-center">
-										<input
-											type="text"
-											value={track.episode_number ?? ''}
-											onchange={(e) => handleEpisodeNumberInput(track.id, e.currentTarget.value)}
-											placeholder="--"
-											disabled={track.excluded}
-											class="w-10 rounded-sm border border-primary/25 bg-primary/5 px-1 py-0.5 text-center text-xs text-gray-900 focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary disabled:opacity-30 dark:border-primary/30 dark:bg-primary/10 dark:text-white"
-										/>
+										{#if row.trackId}
+											<input
+												type="text"
+												value={row.episodeNumber ?? ''}
+												onchange={(e) => handleEpisodeNumberInput(row.trackId!, e.currentTarget.value)}
+												placeholder="--"
+												disabled={row.excluded}
+												class="w-10 rounded-sm border border-primary/25 bg-primary/5 px-1 py-0.5 text-center text-xs text-gray-900 focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary disabled:opacity-30 dark:border-primary/30 dark:bg-primary/10 dark:text-white"
+											/>
+										{:else}
+											<span class="text-gray-400">—</span>
+										{/if}
 									</td>
 								{/if}
-								<td class="px-3 py-1.5 text-gray-700 dark:text-gray-300">{formatLength(track.duration_seconds)}</td>
-								<td class="px-3 py-1.5 font-mono text-gray-500 dark:text-gray-400">{track.output_path || track.source_ref}</td>
+								<td class="px-3 py-1.5 text-gray-700 dark:text-gray-300">{formatLength(row.durationSeconds)}</td>
+								<td class="px-3 py-1.5 font-mono text-gray-500 dark:text-gray-400">{row.sourceLabel}</td>
 								{#if isVideo}
 									<td class="px-1 py-1.5">
-										<button
-											onclick={() => toggleTrackSearch(track.id)}
-											class="rounded p-1 transition-colors {openSearchTrackIds.has(track.id) ? 'text-primary' : 'text-gray-400 hover:text-primary dark:text-gray-500 dark:hover:text-primary'}"
-											title={openSearchTrackIds.has(track.id) ? 'Close search' : 'Search title'}
-										>
-											<svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
-												<circle cx="11" cy="11" r="8" /><path d="m21 21-4.35-4.35" />
-											</svg>
-										</button>
+										{#if row.trackId}
+											<button
+												onclick={() => toggleTrackSearch(row.trackId!)}
+												class="rounded p-1 transition-colors {openSearchTrackIds.has(row.trackId) ? 'text-primary' : 'text-gray-400 hover:text-primary dark:text-gray-500 dark:hover:text-primary'}"
+												title={openSearchTrackIds.has(row.trackId) ? 'Close search' : 'Search title'}
+											>
+												<svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+													<circle cx="11" cy="11" r="8" /><path d="m21 21-4.35-4.35" />
+												</svg>
+											</button>
+										{/if}
 									</td>
 								{/if}
 							</tr>
-							{#if isVideo && openSearchTrackIds.has(track.id)}
+							{#if isVideo && row.trackId && openSearchTrackIds.has(row.trackId)}
 								<tr>
 									<td colspan="99" class="px-3 py-2">
-										<TrackTitleSearch jobId={job.id} {track} onapply={() => handleTrackTitleApply(track.id)} onclear={() => onrefresh?.()} onclose={() => toggleTrackSearch(track.id)} />
+										<TrackTitleSearch jobId={job.id} track={tracks.find((t) => t.id === row.trackId)!} onapply={() => handleTrackTitleApply(row.trackId!)} onclear={() => onrefresh?.()} onclose={() => toggleTrackSearch(row.trackId!)} />
 									</td>
 								</tr>
 							{/if}

--- a/services/ui-neu/frontend/src/lib/components/ReviewTracksTable.test.ts
+++ b/services/ui-neu/frontend/src/lib/components/ReviewTracksTable.test.ts
@@ -28,6 +28,17 @@ afterEach(() => {
 	cleanup();
 });
 
+function scanTitle(overrides: Record<string, unknown> = {}) {
+	return {
+		index: 0,
+		duration_seconds: 4568,
+		chapter_count: 6,
+		size_bytes: 1993701376,
+		source_file: 'B1_t00.mkv',
+		...overrides
+	} as any;
+}
+
 describe('ReviewTracksTable', () => {
 	it('renders a row per track', () => {
 		renderComponent(ReviewTracksTable, {
@@ -55,5 +66,55 @@ describe('ReviewTracksTable', () => {
 		await fireEvent.click(screen.getByText(/^X/));
 		// TrackTitleSearch renders a search input with placeholder "Title..."
 		await waitFor(() => expect(screen.getByPlaceholderText('Title...')).toBeInTheDocument());
+	});
+
+	it('falls back to scanned titles when there are no materialized tracks', () => {
+		renderComponent(ReviewTracksTable, {
+			props: {
+				job,
+				tracks: [],
+				scanTitles: [scanTitle({ index: 0 }), scanTitle({ index: 1, source_file: 'B1_t01.mkv' })],
+				isVideo: true,
+				isMusic: false,
+				onrefresh: vi.fn()
+			}
+		});
+		expect(screen.getByText('Scanned titles (2)')).toBeInTheDocument();
+		// length rendered from the scan (4568s -> 1h 16m 8s)
+		expect(screen.getAllByText(/1h 16m/).length).toBeGreaterThan(0);
+		// read-only: no episode input rendered for scanned rows
+		expect(screen.queryByPlaceholderText('--')).not.toBeInTheDocument();
+	});
+
+	it('materialized tracks win over scanned titles when both are present', () => {
+		renderComponent(ReviewTracksTable, {
+			props: {
+				job,
+				tracks: [track()],
+				scanTitles: [scanTitle(), scanTitle({ index: 1 }), scanTitle({ index: 2 })],
+				isVideo: true,
+				isMusic: false,
+				onrefresh: vi.fn()
+			}
+		});
+		expect(screen.getByText('Tracks (1)')).toBeInTheDocument();
+		expect(screen.queryByText(/Scanned titles/)).not.toBeInTheDocument();
+	});
+
+	it('shows "No tracks yet." when there are neither tracks nor scanned titles', () => {
+		renderComponent(ReviewTracksTable, {
+			props: { job, tracks: [], scanTitles: [], isVideo: true, isMusic: false, onrefresh: vi.fn() }
+		});
+		expect(screen.getByText('No tracks yet.')).toBeInTheDocument();
+	});
+
+	it('a scanned title row is read-only (clicking it does not open TrackTitleSearch)', async () => {
+		renderComponent(ReviewTracksTable, {
+			props: { job, tracks: [], scanTitles: [scanTitle()], isVideo: true, isMusic: false, onrefresh: vi.fn() }
+		});
+		// the title cell shows an em-dash and is not clickable → no search field appears
+		// (isVideo: true also renders a second em-dash in the episode column, so use getAllByText)
+		await fireEvent.click(screen.getAllByText('—')[0]);
+		expect(screen.queryByPlaceholderText('Title...')).not.toBeInTheDocument();
 	});
 });

--- a/services/ui-neu/frontend/src/lib/utils/review-rows.test.ts
+++ b/services/ui-neu/frontend/src/lib/utils/review-rows.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { trackToRow, scanTitleToRow } from './review-rows';
+
+describe('review-rows mappers', () => {
+	it('trackToRow carries the id + editable fields', () => {
+		const r = trackToRow({
+			id: 'trk_9', index: 3, title: 'Main', year: 2001, episode_number: 4,
+			excluded: false, duration_seconds: 60, output_path: 'o.mkv', source_ref: 's'
+		} as any);
+		expect(r).toEqual({
+			index: 3, durationSeconds: 60, sourceLabel: 'o.mkv', trackId: 'trk_9',
+			title: 'Main', year: 2001, episodeNumber: 4, excluded: false
+		});
+	});
+
+	it('trackToRow falls back to source_ref when output_path is empty', () => {
+		const r = trackToRow({ id: 't', index: 0, title: null, year: null, episode_number: null, excluded: false, duration_seconds: null, output_path: null, source_ref: 'B1_t00' } as any);
+		expect(r.sourceLabel).toBe('B1_t00');
+	});
+
+	it('scanTitleToRow has no trackId and blank identity (read-only row)', () => {
+		const r = scanTitleToRow({ index: 2, duration_seconds: 100, source_file: 'x.mkv' } as any);
+		expect(r).toEqual({
+			index: 2, durationSeconds: 100, sourceLabel: 'x.mkv', trackId: null,
+			title: null, year: null, episodeNumber: null, excluded: false
+		});
+	});
+
+	it('scanTitleToRow tolerates a missing source_file', () => {
+		const r = scanTitleToRow({ index: 0, duration_seconds: 10 } as any);
+		expect(r.sourceLabel).toBeNull();
+	});
+});

--- a/services/ui-neu/frontend/src/lib/utils/review-rows.ts
+++ b/services/ui-neu/frontend/src/lib/utils/review-rows.ts
@@ -1,0 +1,41 @@
+import type { TrackView, ScanTitle } from '$lib/types/api.gen';
+
+// One row shape covering both review-card lifecycle stages. A row is editable iff
+// it has a real materialized-track id; scanned-title rows (trackId === null) are
+// read-only.
+export type ReviewRow = {
+	index: number;
+	durationSeconds: number | null;
+	sourceLabel: string | null;
+	trackId: string | null;
+	title: string | null;
+	year: number | null;
+	episodeNumber: number | null;
+	excluded: boolean;
+};
+
+export function trackToRow(t: TrackView): ReviewRow {
+	return {
+		index: t.index,
+		durationSeconds: t.duration_seconds,
+		sourceLabel: t.output_path || t.source_ref,
+		trackId: t.id,
+		title: t.title ?? null,
+		year: t.year ?? null,
+		episodeNumber: t.episode_number ?? null,
+		excluded: t.excluded ?? false
+	};
+}
+
+export function scanTitleToRow(s: ScanTitle): ReviewRow {
+	return {
+		index: s.index,
+		durationSeconds: s.duration_seconds,
+		sourceLabel: s.source_file ?? null,
+		trackId: null,
+		title: null,
+		year: null,
+		episodeNumber: null,
+		excluded: false
+	};
+}


### PR DESCRIPTION
Surfaces a scanned disc's titles in the review card's tracks table BEFORE rip (read-only unified rows: scanned titles pre-rip, materialized Track rows post-rip). Stacks on Tier-20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)