### PR TITLE
feat: Tier-22 — detail page show-all-metadata + JSON tree (ui-neu)

### DIFF
--- a/services/ui-neu/frontend/src/lib/components/DiscReviewWidget.svelte
+++ b/services/ui-neu/frontend/src/lib/components/DiscReviewWidget.svelte
@@ -273,15 +273,6 @@
 		{/if}
 	</div>
 
-	<!-- Tracks table -->
-	<div class="border-t border-primary/20 dark:border-primary/20">
-		{#if initialLoading}
-			<p class="p-4 text-sm text-gray-400">Loading...</p>
-		{:else}
-			<ReviewTracksTable {job} {tracks} {scanTitles} {isVideo} {isMusic} onrefresh={() => { onrefresh?.(); loadDetail(); }} />
-		{/if}
-	</div>
-
 	<!-- Expanded sections -->
 	{#if showTitleSearch && isVideo}
 		<div class="border-t border-primary/20 p-4 dark:border-primary/20">
@@ -297,6 +288,14 @@
 
 	{#if showInfo}
 		<JobInfoForm {job} onrefresh={() => { onrefresh?.(); loadDetail(); }} />
+		<!-- Scanned titles (pre-rip) / tracks (post-rip) live at the bottom of the Info tab -->
+		<div class="border-t border-primary/20 dark:border-primary/20">
+			{#if initialLoading}
+				<p class="p-4 text-sm text-gray-400">Loading...</p>
+			{:else}
+				<ReviewTracksTable {job} {tracks} {scanTitles} {isVideo} {isMusic} onrefresh={() => { onrefresh?.(); loadDetail(); }} />
+			{/if}
+		</div>
 	{/if}
 </div>
 

--- a/services/ui-neu/frontend/src/lib/components/DiscReviewWidget.svelte
+++ b/services/ui-neu/frontend/src/lib/components/DiscReviewWidget.svelte
@@ -250,14 +250,14 @@
 		<button onclick={() => (showApplySession = true)} class="{btnBase} bg-primary/5 text-gray-700 ring-1 ring-primary/25 hover:bg-primary/10 dark:bg-primary/10 dark:text-gray-200 dark:ring-primary/30 dark:hover:bg-primary/15">Apply session</button>
 		<a
 			href="/jobs/{job.id}"
-			class="{btnBase} ml-auto bg-primary/5 text-gray-700 ring-1 ring-primary/25 hover:bg-primary/10 dark:bg-primary/10 dark:text-gray-200 dark:ring-primary/30 dark:hover:bg-primary/15"
+			class="{btnBase} bg-primary/5 text-gray-700 ring-1 ring-primary/25 hover:bg-primary/10 dark:bg-primary/10 dark:text-gray-200 dark:ring-primary/30 dark:hover:bg-primary/15"
 		>
 			View details
 		</a>
 		<button
 			onclick={handleCancel}
 			disabled={cancelling}
-			class="{btnBase} text-red-600 ring-1 ring-red-300 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:ring-red-700 dark:hover:bg-red-900/20"
+			class="{btnBase} ml-auto text-red-600 ring-1 ring-red-300 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:ring-red-700 dark:hover:bg-red-900/20"
 		>
 			{cancelling ? 'Cancelling...' : 'Cancel'}
 		</button>

--- a/services/ui-neu/frontend/src/lib/components/DiscReviewWidget.test.ts
+++ b/services/ui-neu/frontend/src/lib/components/DiscReviewWidget.test.ts
@@ -226,6 +226,9 @@ describe('DiscReviewWidget', () => {
 				])
 			);
 			renderWidget({ disc_type: 'bluray' });
+			// The tracks table now lives at the bottom of the Info tab — open it first.
+			await waitFor(() => expect(screen.getByRole('button', { name: 'Info' })).toBeInTheDocument());
+			await fireEvent.click(screen.getByRole('button', { name: 'Info' }));
 			await waitFor(() => {
 				expect(screen.getByText('Demon in Lace')).toBeInTheDocument();
 				expect(screen.getByText('Kolchak_t00.mkv')).toBeInTheDocument();
@@ -237,6 +240,9 @@ describe('DiscReviewWidget', () => {
 				detail({ disc_type: 'bluray' }, [createTrack({ id: 'trk_1', index: 0, source_ref: 't00.mkv', title: 'Ep' })])
 			);
 			renderWidget({ id: 'job_3', disc_type: 'bluray' });
+			// The tracks table now lives at the bottom of the Info tab — open it first.
+			await waitFor(() => expect(screen.getByRole('button', { name: 'Info' })).toBeInTheDocument());
+			await fireEvent.click(screen.getByRole('button', { name: 'Info' }));
 			await waitFor(() => expect(screen.getByText('Ep')).toBeInTheDocument());
 			const epInput = screen.getByPlaceholderText('--');
 			await fireEvent.change(epInput, { target: { value: '7' } });
@@ -271,6 +277,9 @@ describe('DiscReviewWidget', () => {
 			)
 		);
 		renderWidget({ status: 'awaiting_user_id' });
+		// The tracks table now lives at the bottom of the Info tab — open it first.
+		await waitFor(() => expect(screen.getByRole('button', { name: 'Info' })).toBeInTheDocument());
+		await fireEvent.click(screen.getByRole('button', { name: 'Info' }));
 		await waitFor(() => expect(screen.getByText('Scanned titles (2)')).toBeInTheDocument());
 	});
 });

--- a/services/ui-neu/frontend/src/lib/components/JsonTree.svelte
+++ b/services/ui-neu/frontend/src/lib/components/JsonTree.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import { classifyJsonValue } from '$lib/utils/json-tree';
+	import Self from './JsonTree.svelte';
+
+	interface Props {
+		value: unknown;
+		name?: string;
+		depth?: number;
+	}
+	let { value, name, depth = 0 }: Props = $props();
+
+	let node = $derived(classifyJsonValue(value));
+	// Top level expanded, nested collapsed: a container opens when depth <= 1.
+	// $state(expr) evaluates the initial-prop expression once at construction,
+	// so this seeds the open state from the depth rule and the user's clicks
+	// take over thereafter. Each child <Self> is a fresh instance with its own
+	// `open`, so the seed runs per node at its own depth.
+	let open = $state(classifyJsonValue(value).isContainer && depth <= 1);
+
+	const scalarClass: Record<string, string> = {
+		string: 'text-gray-900 dark:text-white',
+		number: 'text-amber-600 dark:text-amber-400',
+		boolean: 'text-gray-400 italic',
+		null: 'text-gray-400 italic'
+	};
+</script>
+
+{#if node.isContainer}
+	<div class="font-mono text-xs">
+		<button
+			type="button"
+			onclick={() => { open = !open; }}
+			class="flex w-full items-center gap-1 py-0.5 text-left hover:bg-page dark:hover:bg-gray-800/50"
+		>
+			<svg class="h-3 w-3 shrink-0 transition-transform {open ? 'rotate-90' : ''}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+			</svg>
+			{#if name !== undefined}
+				<span class="text-gray-500 dark:text-gray-400">{name}</span>
+			{/if}
+			<span class="text-gray-400 dark:text-gray-500">{node.preview}</span>
+		</button>
+		{#if open}
+			<div class="ml-3 border-l border-primary/15 pl-2 dark:border-primary/15">
+				{#each node.entries as entry}
+					<Self value={entry.value} name={entry.key} depth={depth + 1} />
+				{/each}
+			</div>
+		{/if}
+	</div>
+{:else}
+	<div class="flex items-baseline gap-1 py-0.5 font-mono text-xs">
+		{#if name !== undefined}
+			<span class="text-gray-500 dark:text-gray-400">{name}</span><span class="text-gray-400 dark:text-gray-500">:</span>
+		{/if}
+		<span class={scalarClass[node.kind] ?? 'text-gray-900 dark:text-white'}>{node.preview}</span>
+	</div>
+{/if}

--- a/services/ui-neu/frontend/src/lib/components/JsonTree.test.ts
+++ b/services/ui-neu/frontend/src/lib/components/JsonTree.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderComponent, screen, cleanup, fireEvent } from '$lib/test-utils';
+import JsonTree from './JsonTree.svelte';
+
+describe('JsonTree', () => {
+	afterEach(() => cleanup());
+
+	it('renders a scalar as name: value with no disclosure button', () => {
+		renderComponent(JsonTree, { props: { name: 'disc_type', value: 'dvd' } });
+		expect(screen.getByText('disc_type')).toBeInTheDocument();
+		expect(screen.getByText('dvd')).toBeInTheDocument();
+		expect(screen.queryByRole('button')).not.toBeInTheDocument();
+	});
+
+	it('renders a container as a disclosure button with a preview', () => {
+		renderComponent(JsonTree, { props: { name: 'scan_result', value: { a: 1 }, depth: 0 } });
+		const btn = screen.getByRole('button');
+		expect(btn).toHaveTextContent('scan_result');
+		expect(btn).toHaveTextContent('{…}');
+	});
+
+	it('is open at depth 0 (children visible)', () => {
+		renderComponent(JsonTree, { props: { name: 'root', value: { child_key: 'child_val' }, depth: 0 } });
+		expect(screen.getByText('child_key')).toBeInTheDocument();
+		expect(screen.getByText('child_val')).toBeInTheDocument();
+	});
+
+	it('is collapsed at depth 2 (children hidden until clicked)', async () => {
+		renderComponent(JsonTree, { props: { name: 'deep', value: { hidden_key: 'hidden_val' }, depth: 2 } });
+		expect(screen.queryByText('hidden_key')).not.toBeInTheDocument();
+		await fireEvent.click(screen.getByRole('button'));
+		expect(screen.getByText('hidden_key')).toBeInTheDocument();
+	});
+
+	it('toggles a node closed when clicked while open', async () => {
+		renderComponent(JsonTree, { props: { name: 'root', value: { k: 'v' }, depth: 0 } });
+		expect(screen.getByText('k')).toBeInTheDocument();
+		await fireEvent.click(screen.getByRole('button'));
+		expect(screen.queryByText('k')).not.toBeInTheDocument();
+	});
+
+	it('renders an empty object inline (no disclosure button)', () => {
+		renderComponent(JsonTree, { props: { name: 'raw', value: {}, depth: 0 } });
+		expect(screen.getByText('raw')).toBeInTheDocument();
+		expect(screen.getByText('{}')).toBeInTheDocument();
+		expect(screen.queryByRole('button')).not.toBeInTheDocument();
+	});
+
+	it('recurses: nested array reachable, deep item collapsed', async () => {
+		renderComponent(JsonTree, {
+			props: { name: 'scan_result', value: { titles: [{ index: 0 }] }, depth: 0 }
+		});
+		// depth 0 (scan_result) open, depth 1 (titles) open → "titles" disclosure visible
+		expect(screen.getByText('titles')).toBeInTheDocument();
+		// titles is an array container; its [0] child sits at depth 2 → collapsed,
+		// so the leaf "index" is not yet shown.
+		expect(screen.queryByText('index')).not.toBeInTheDocument();
+	});
+});

--- a/services/ui-neu/frontend/src/lib/components/__tests__/DiscReviewWidget.test.ts
+++ b/services/ui-neu/frontend/src/lib/components/__tests__/DiscReviewWidget.test.ts
@@ -48,6 +48,9 @@ describe('DiscReviewWidget', () => {
 	describe('tracks', () => {
 		it('renders the v3 tracks table from data.tracks', async () => {
 			renderWidget();
+			// The tracks table now lives at the bottom of the Info tab — open it first.
+			await waitFor(() => expect(screen.getByRole('button', { name: 'Info' })).toBeInTheDocument());
+			await fireEvent.click(screen.getByRole('button', { name: 'Info' }));
 			await waitFor(() => {
 				expect(screen.getByText('Main')).toBeInTheDocument();
 				expect(screen.getByText('t00.mkv')).toBeInTheDocument();

--- a/services/ui-neu/frontend/src/lib/utils/job-fields.test.ts
+++ b/services/ui-neu/frontend/src/lib/utils/job-fields.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { readJobMetadata, videoTypeLabel } from './job-fields';
+
+describe('readJobMetadata', () => {
+	it('returns empty object fields for an empty blob', () => {
+		expect(readJobMetadata({})).toEqual({});
+	});
+
+	it('returns empty for null/undefined without throwing', () => {
+		expect(readJobMetadata(null)).toEqual({});
+		expect(readJobMetadata(undefined)).toEqual({});
+	});
+
+	it('reads well-formed known scalars', () => {
+		const md = {
+			imdb_id: 'tt1234567',
+			tmdb_id: '603',
+			tvdb_id: '81189',
+			video_type: 'series',
+			season: '2',
+			artist: 'The Beatles',
+			album: 'Abbey Road',
+			multi_title: true,
+			source_type: 'iso'
+		};
+		expect(readJobMetadata(md)).toEqual({
+			imdb_id: 'tt1234567',
+			tmdb_id: '603',
+			tvdb_id: '81189',
+			video_type: 'series',
+			season: '2',
+			artist: 'The Beatles',
+			album: 'Abbey Road',
+			multi_title: true,
+			source_type: 'iso'
+		});
+	});
+
+	it('coerces numeric ids/season to strings', () => {
+		expect(readJobMetadata({ tmdb_id: 603, season: 2 })).toEqual({
+			tmdb_id: '603',
+			season: '2'
+		});
+	});
+
+	it('ignores malformed (non-scalar) known keys', () => {
+		expect(readJobMetadata({ imdb_id: { nested: 1 }, video_type: ['a'] })).toEqual({});
+	});
+
+	it('derives titleCount from scan_result.titles length', () => {
+		expect(
+			readJobMetadata({ scan_result: { titles: [{ index: 0 }, { index: 1 }] } })
+		).toEqual({ titleCount: 2 });
+	});
+
+	it('omits titleCount when scan_result has no titles array', () => {
+		expect(readJobMetadata({ scan_result: { raw: {} } })).toEqual({});
+	});
+});
+
+describe('videoTypeLabel', () => {
+	it('maps known types', () => {
+		expect(videoTypeLabel('movie')).toBe('Movie');
+		expect(videoTypeLabel('series')).toBe('Series');
+		expect(videoTypeLabel('music')).toBe('Music');
+		expect(videoTypeLabel('data')).toBe('Data');
+	});
+	it('passes through unknown and falls back for empty', () => {
+		expect(videoTypeLabel('anime')).toBe('anime');
+		expect(videoTypeLabel(null)).toBe('Unknown');
+	});
+});

--- a/services/ui-neu/frontend/src/lib/utils/job-fields.test.ts
+++ b/services/ui-neu/frontend/src/lib/utils/job-fields.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { readJobMetadata, videoTypeLabel } from './job-fields';
+import { readJobMetadata, videoTypeLabel, buildMetadataFields } from './job-fields';
+import { createJob } from '$lib/components/__fixtures__/job';
 
 describe('readJobMetadata', () => {
 	it('returns empty object fields for an empty blob', () => {
@@ -68,5 +69,85 @@ describe('videoTypeLabel', () => {
 	it('passes through unknown and falls back for empty', () => {
 		expect(videoTypeLabel('anime')).toBe('anime');
 		expect(videoTypeLabel(null)).toBe('Unknown');
+	});
+});
+
+const fieldByLabel = (fields: ReturnType<typeof buildMetadataFields>, label: string) =>
+	fields.find((f) => f.label === label);
+
+describe('buildMetadataFields — promoted fields', () => {
+	it('promotes Disc # with total', () => {
+		const fields = buildMetadataFields(createJob({ disc_number: 1, disc_total: 2 }));
+		expect(fieldByLabel(fields, 'Disc #')?.value).toBe('1 of 2');
+	});
+
+	it('promotes Disc # without total', () => {
+		const fields = buildMetadataFields(createJob({ disc_number: 1, disc_total: null }));
+		expect(fieldByLabel(fields, 'Disc #')?.value).toBe('1');
+	});
+
+	it('shows Poster source Manual then Auto', () => {
+		expect(
+			fieldByLabel(buildMetadataFields(createJob({ poster_url_manual: 'm', poster_url: 'a' })), 'Poster')?.value
+		).toBe('Manual');
+		expect(
+			fieldByLabel(buildMetadataFields(createJob({ poster_url_manual: null, poster_url: 'a' })), 'Poster')?.value
+		).toBe('Auto');
+		expect(
+			fieldByLabel(buildMetadataFields(createJob({ poster_url_manual: null, poster_url: null })), 'Poster')
+		).toBeUndefined();
+	});
+
+	it('promotes Type / IMDb (link) / TMDB (link) / TVDB (link) / Season from metadata_json', () => {
+		const fields = buildMetadataFields(
+			createJob({
+				metadata_json: {
+					video_type: 'series',
+					imdb_id: 'tt1234567',
+					tmdb_id: '603',
+					tvdb_id: '81189',
+					season: '2'
+				}
+			})
+		);
+		expect(fieldByLabel(fields, 'Type')?.value).toBe('Series');
+		expect(fieldByLabel(fields, 'IMDb')?.link).toBe('https://www.imdb.com/title/tt1234567');
+		expect(fieldByLabel(fields, 'TMDB')?.link).toBe('https://www.themoviedb.org/movie/603');
+		expect(fieldByLabel(fields, 'TVDB')?.link).toBe('https://www.thetvdb.com/dereferrer/series/81189');
+		expect(fieldByLabel(fields, 'Season')?.value).toBe('2');
+	});
+
+	it('promotes Artist / Album', () => {
+		const fields = buildMetadataFields(
+			createJob({ metadata_json: { artist: 'The Beatles', album: 'Abbey Road' } })
+		);
+		expect(fieldByLabel(fields, 'Artist')?.value).toBe('The Beatles');
+		expect(fieldByLabel(fields, 'Album')?.value).toBe('Abbey Road');
+	});
+
+	it('adds Titles count only when rip_progress is absent', () => {
+		const scanned = buildMetadataFields(
+			createJob({ rip_progress: null, metadata_json: { scan_result: { titles: [{}, {}, {}] } } })
+		);
+		expect(fieldByLabel(scanned, 'Titles')?.value).toBe('3');
+
+		const ripping = buildMetadataFields(
+			createJob({
+				rip_progress: { tracks_done: 1, tracks_total: 3, tracks_failed: 0, current_track_id: null, current_track_index: null },
+				metadata_json: { scan_result: { titles: [{}, {}, {}] } }
+			})
+		);
+		// Base "Tracks" cell is authoritative; "Titles" not added.
+		expect(fieldByLabel(ripping, 'Titles')).toBeUndefined();
+		expect(fieldByLabel(ripping, 'Tracks')?.value).toBe('1 / 3');
+	});
+
+	it('promotes nothing extra for a bare job (only base cells, padded)', () => {
+		const fields = buildMetadataFields(createJob({ metadata_json: {} }));
+		for (const label of ['Disc #', 'Poster', 'Type', 'IMDb', 'TMDB', 'TVDB', 'Season', 'Artist', 'Album', 'Titles']) {
+			expect(fieldByLabel(fields, label)).toBeUndefined();
+		}
+		// Length is a multiple of 4 (pad preserved).
+		expect(fields.length % 4).toBe(0);
 	});
 });

--- a/services/ui-neu/frontend/src/lib/utils/job-fields.test.ts
+++ b/services/ui-neu/frontend/src/lib/utils/job-fields.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readJobMetadata, videoTypeLabel, buildMetadataFields, metadataEntries } from './job-fields';
+import { readJobMetadata, videoTypeLabel, buildMetadataFields } from './job-fields';
 import { createJob } from '$lib/components/__fixtures__/job';
 
 describe('readJobMetadata', () => {
@@ -152,30 +152,3 @@ describe('buildMetadataFields — promoted fields', () => {
 	});
 });
 
-describe('metadataEntries', () => {
-	it('returns [] for empty/missing blob', () => {
-		expect(metadataEntries({})).toEqual([]);
-		expect(metadataEntries(null)).toEqual([]);
-		expect(metadataEntries(undefined)).toEqual([]);
-	});
-
-	it('renders scalars inline (isJson false)', () => {
-		expect(metadataEntries({ imdb_id: 'tt1', multi_title: true, season: 2 })).toEqual([
-			{ key: 'imdb_id', display: 'tt1', isJson: false },
-			{ key: 'multi_title', display: 'true', isJson: false },
-			{ key: 'season', display: '2', isJson: false }
-		]);
-	});
-
-	it('pretty-prints objects/arrays (isJson true)', () => {
-		const entries = metadataEntries({ scan_result: { titles: [{ index: 0 }] } });
-		expect(entries).toHaveLength(1);
-		expect(entries[0].key).toBe('scan_result');
-		expect(entries[0].isJson).toBe(true);
-		expect(entries[0].display).toBe(JSON.stringify({ titles: [{ index: 0 }] }, null, 2));
-	});
-
-	it('renders null/undefined values as empty string scalars', () => {
-		expect(metadataEntries({ a: null })).toEqual([{ key: 'a', display: '', isJson: false }]);
-	});
-});

--- a/services/ui-neu/frontend/src/lib/utils/job-fields.test.ts
+++ b/services/ui-neu/frontend/src/lib/utils/job-fields.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readJobMetadata, videoTypeLabel, buildMetadataFields } from './job-fields';
+import { readJobMetadata, videoTypeLabel, buildMetadataFields, metadataEntries } from './job-fields';
 import { createJob } from '$lib/components/__fixtures__/job';
 
 describe('readJobMetadata', () => {
@@ -149,5 +149,33 @@ describe('buildMetadataFields — promoted fields', () => {
 		}
 		// Length is a multiple of 4 (pad preserved).
 		expect(fields.length % 4).toBe(0);
+	});
+});
+
+describe('metadataEntries', () => {
+	it('returns [] for empty/missing blob', () => {
+		expect(metadataEntries({})).toEqual([]);
+		expect(metadataEntries(null)).toEqual([]);
+		expect(metadataEntries(undefined)).toEqual([]);
+	});
+
+	it('renders scalars inline (isJson false)', () => {
+		expect(metadataEntries({ imdb_id: 'tt1', multi_title: true, season: 2 })).toEqual([
+			{ key: 'imdb_id', display: 'tt1', isJson: false },
+			{ key: 'multi_title', display: 'true', isJson: false },
+			{ key: 'season', display: '2', isJson: false }
+		]);
+	});
+
+	it('pretty-prints objects/arrays (isJson true)', () => {
+		const entries = metadataEntries({ scan_result: { titles: [{ index: 0 }] } });
+		expect(entries).toHaveLength(1);
+		expect(entries[0].key).toBe('scan_result');
+		expect(entries[0].isJson).toBe(true);
+		expect(entries[0].display).toBe(JSON.stringify({ titles: [{ index: 0 }] }, null, 2));
+	});
+
+	it('renders null/undefined values as empty string scalars', () => {
+		expect(metadataEntries({ a: null })).toEqual([{ key: 'a', display: '', isJson: false }]);
 	});
 });

--- a/services/ui-neu/frontend/src/lib/utils/job-fields.ts
+++ b/services/ui-neu/frontend/src/lib/utils/job-fields.ts
@@ -128,7 +128,7 @@ export function buildMetadataFields(job: JobView): MetadataField[] {
 	if (md.video_type) {
 		fields.push({ label: 'Type', value: videoTypeLabel(md.video_type) });
 	}
-	if (md.imdb_id) {
+	if (md.imdb_id && job.disc_type !== 'cd') {
 		fields.push({ label: 'IMDb', value: md.imdb_id, link: `https://www.imdb.com/title/${md.imdb_id}` });
 	}
 	if (md.tmdb_id) {

--- a/services/ui-neu/frontend/src/lib/utils/job-fields.ts
+++ b/services/ui-neu/frontend/src/lib/utils/job-fields.ts
@@ -162,3 +162,27 @@ export function buildMetadataFields(job: JobView): MetadataField[] {
 
 	return fields;
 }
+
+export interface MetadataEntry {
+	key: string;
+	display: string;
+	isJson: boolean;
+}
+
+/**
+ * Flatten a job's `metadata_json` into one row per TOP-LEVEL key for the raw
+ * viewer. Scalars render inline; objects/arrays are pretty-printed JSON so
+ * structured values (scan_result, tracks, raw) are fully visible without
+ * being flattened into the grid. Returns [] for an empty/missing blob.
+ */
+export function metadataEntries(
+	metadata_json: Record<string, unknown> | null | undefined
+): MetadataEntry[] {
+	const md = (metadata_json ?? {}) as Record<string, unknown>;
+	return Object.entries(md).map(([key, value]) => {
+		if (value !== null && typeof value === 'object') {
+			return { key, display: JSON.stringify(value, null, 2), isJson: true };
+		}
+		return { key, display: value == null ? '' : String(value), isJson: false };
+	});
+}

--- a/services/ui-neu/frontend/src/lib/utils/job-fields.ts
+++ b/services/ui-neu/frontend/src/lib/utils/job-fields.ts
@@ -10,6 +10,76 @@ export interface MetadataField {
 	empty?: boolean;
 }
 
+export interface JobMetadata {
+	imdb_id?: string;
+	tmdb_id?: string;
+	tvdb_id?: string;
+	video_type?: string;
+	season?: string;
+	artist?: string;
+	album?: string;
+	multi_title?: boolean;
+	source_type?: string;
+	titleCount?: number;
+}
+
+function asScalarString(v: unknown): string | undefined {
+	if (typeof v === 'string') return v;
+	if (typeof v === 'number' && Number.isFinite(v)) return String(v);
+	return undefined;
+}
+
+/**
+ * Read the known scalar keys out of a job's freeform `metadata_json`.
+ * Every read is guarded so a missing or malformed blob yields `undefined`
+ * for that key (never throws). Structured values (scan_result, tracks, raw)
+ * are intentionally NOT surfaced here — they belong to the raw viewer.
+ */
+export function readJobMetadata(
+	metadata_json: Record<string, unknown> | null | undefined
+): JobMetadata {
+	const md = (metadata_json ?? {}) as Record<string, unknown>;
+	const out: JobMetadata = {};
+
+	const imdb = asScalarString(md.imdb_id);
+	if (imdb !== undefined) out.imdb_id = imdb;
+	const tmdb = asScalarString(md.tmdb_id);
+	if (tmdb !== undefined) out.tmdb_id = tmdb;
+	const tvdb = asScalarString(md.tvdb_id);
+	if (tvdb !== undefined) out.tvdb_id = tvdb;
+	const vt = asScalarString(md.video_type);
+	if (vt !== undefined) out.video_type = vt;
+	const season = asScalarString(md.season);
+	if (season !== undefined) out.season = season;
+	const artist = asScalarString(md.artist);
+	if (artist !== undefined) out.artist = artist;
+	const album = asScalarString(md.album);
+	if (album !== undefined) out.album = album;
+	if (typeof md.multi_title === 'boolean') out.multi_title = md.multi_title;
+	const source = asScalarString(md.source_type);
+	if (source !== undefined) out.source_type = source;
+
+	const scan = md.scan_result;
+	if (scan && typeof scan === 'object') {
+		const titles = (scan as Record<string, unknown>).titles;
+		if (Array.isArray(titles)) out.titleCount = titles.length;
+	}
+
+	return out;
+}
+
+const VIDEO_TYPE_LABELS: Record<string, string> = {
+	movie: 'Movie',
+	series: 'Series',
+	music: 'Music',
+	data: 'Data'
+};
+
+export function videoTypeLabel(vt: string | null | undefined): string {
+	if (!vt) return 'Unknown';
+	return VIDEO_TYPE_LABELS[vt.toLowerCase()] ?? vt;
+}
+
 // v3 JobView exposes only a small set of fields. The rich BFF metadata
 // (video_type, label, devpath, multi_title, crc_id, imdb_id, season,
 // tvdb_id, artist/album, output paths, stop_time, job_length, …) has no

--- a/services/ui-neu/frontend/src/lib/utils/job-fields.ts
+++ b/services/ui-neu/frontend/src/lib/utils/job-fields.ts
@@ -111,6 +111,46 @@ export function buildMetadataFields(job: JobView): MetadataField[] {
 		fields.push({ label: 'State', value: 'Finished' });
 	}
 
+	// --- Promoted real JobView columns ---
+	if (job.disc_number != null) {
+		const discValue =
+			job.disc_total != null ? `${job.disc_number} of ${job.disc_total}` : String(job.disc_number);
+		fields.push({ label: 'Disc #', value: discValue });
+	}
+	if (job.poster_url_manual) {
+		fields.push({ label: 'Poster', value: 'Manual' });
+	} else if (job.poster_url) {
+		fields.push({ label: 'Poster', value: 'Auto' });
+	}
+
+	// --- Promoted metadata_json known scalars ---
+	const md = readJobMetadata(job.metadata_json);
+	if (md.video_type) {
+		fields.push({ label: 'Type', value: videoTypeLabel(md.video_type) });
+	}
+	if (md.imdb_id) {
+		fields.push({ label: 'IMDb', value: md.imdb_id, link: `https://www.imdb.com/title/${md.imdb_id}` });
+	}
+	if (md.tmdb_id) {
+		fields.push({ label: 'TMDB', value: md.tmdb_id, link: `https://www.themoviedb.org/movie/${md.tmdb_id}` });
+	}
+	if (md.tvdb_id) {
+		fields.push({ label: 'TVDB', value: md.tvdb_id, link: `https://www.thetvdb.com/dereferrer/series/${md.tvdb_id}` });
+	}
+	if (md.season) {
+		fields.push({ label: 'Season', value: md.season });
+	}
+	if (md.artist) {
+		fields.push({ label: 'Artist', value: md.artist });
+	}
+	if (md.album) {
+		fields.push({ label: 'Album', value: md.album });
+	}
+	// Scanned-title count: only when the base "Tracks" cell (rip_progress) is absent.
+	if (!job.rip_progress && md.titleCount != null) {
+		fields.push({ label: 'Titles', value: String(md.titleCount) });
+	}
+
 	// --- Pad to multiple of 4 ---
 	const remainder = fields.length % 4;
 	if (remainder !== 0) {

--- a/services/ui-neu/frontend/src/lib/utils/job-fields.ts
+++ b/services/ui-neu/frontend/src/lib/utils/job-fields.ts
@@ -163,26 +163,3 @@ export function buildMetadataFields(job: JobView): MetadataField[] {
 	return fields;
 }
 
-export interface MetadataEntry {
-	key: string;
-	display: string;
-	isJson: boolean;
-}
-
-/**
- * Flatten a job's `metadata_json` into one row per TOP-LEVEL key for the raw
- * viewer. Scalars render inline; objects/arrays are pretty-printed JSON so
- * structured values (scan_result, tracks, raw) are fully visible without
- * being flattened into the grid. Returns [] for an empty/missing blob.
- */
-export function metadataEntries(
-	metadata_json: Record<string, unknown> | null | undefined
-): MetadataEntry[] {
-	const md = (metadata_json ?? {}) as Record<string, unknown>;
-	return Object.entries(md).map(([key, value]) => {
-		if (value !== null && typeof value === 'object') {
-			return { key, display: JSON.stringify(value, null, 2), isJson: true };
-		}
-		return { key, display: value == null ? '' : String(value), isJson: false };
-	});
-}

--- a/services/ui-neu/frontend/src/lib/utils/json-tree.test.ts
+++ b/services/ui-neu/frontend/src/lib/utils/json-tree.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { classifyJsonValue } from './json-tree';
+
+describe('classifyJsonValue', () => {
+	it('classifies a non-empty object', () => {
+		const c = classifyJsonValue({ a: 1, b: 'x' });
+		expect(c.kind).toBe('object');
+		expect(c.isContainer).toBe(true);
+		expect(c.preview).toBe('{…}');
+		expect(c.entries).toEqual([
+			{ key: 'a', value: 1 },
+			{ key: 'b', value: 'x' }
+		]);
+	});
+
+	it('classifies an empty object as a non-container', () => {
+		const c = classifyJsonValue({});
+		expect(c.kind).toBe('object');
+		expect(c.isContainer).toBe(false);
+		expect(c.preview).toBe('{}');
+		expect(c.entries).toEqual([]);
+	});
+
+	it('classifies a non-empty array with index keys', () => {
+		const c = classifyJsonValue(['x', 'y']);
+		expect(c.kind).toBe('array');
+		expect(c.isContainer).toBe(true);
+		expect(c.preview).toBe('[2]');
+		expect(c.entries).toEqual([
+			{ key: '0', value: 'x' },
+			{ key: '1', value: 'y' }
+		]);
+	});
+
+	it('classifies an empty array as a non-container', () => {
+		const c = classifyJsonValue([]);
+		expect(c.kind).toBe('array');
+		expect(c.isContainer).toBe(false);
+		expect(c.preview).toBe('[]');
+		expect(c.entries).toEqual([]);
+	});
+
+	it('classifies a string', () => {
+		const c = classifyJsonValue('hello');
+		expect(c).toEqual({ kind: 'string', isContainer: false, preview: 'hello', entries: [] });
+	});
+
+	it('classifies a number', () => {
+		const c = classifyJsonValue(42);
+		expect(c).toEqual({ kind: 'number', isContainer: false, preview: '42', entries: [] });
+	});
+
+	it('classifies a boolean', () => {
+		expect(classifyJsonValue(true).preview).toBe('true');
+		expect(classifyJsonValue(false).preview).toBe('false');
+		expect(classifyJsonValue(true).kind).toBe('boolean');
+	});
+
+	it('classifies null', () => {
+		expect(classifyJsonValue(null)).toEqual({ kind: 'null', isContainer: false, preview: 'null', entries: [] });
+	});
+
+	it('classifies undefined defensively as null', () => {
+		expect(classifyJsonValue(undefined)).toEqual({ kind: 'null', isContainer: false, preview: 'null', entries: [] });
+	});
+});

--- a/services/ui-neu/frontend/src/lib/utils/json-tree.ts
+++ b/services/ui-neu/frontend/src/lib/utils/json-tree.ts
@@ -1,0 +1,54 @@
+export type JsonKind = 'object' | 'array' | 'string' | 'number' | 'boolean' | 'null';
+
+export interface JsonEntry {
+	key: string;
+	value: unknown;
+}
+
+export interface ClassifiedJson {
+	kind: JsonKind;
+	isContainer: boolean;
+	preview: string;
+	entries: JsonEntry[];
+}
+
+/**
+ * Describe any JSON value for the tree viewer: its kind, whether it has a
+ * disclosure row (non-empty object/array), a collapsed-summary preview, and
+ * its child entries (object pairs, or array index/value pairs). Scalars and
+ * empty containers have no entries. Never throws; `undefined` (not valid JSON)
+ * is treated as null defensively.
+ */
+export function classifyJsonValue(value: unknown): ClassifiedJson {
+	if (value === null || value === undefined) {
+		return { kind: 'null', isContainer: false, preview: 'null', entries: [] };
+	}
+	if (Array.isArray(value)) {
+		const entries: JsonEntry[] = value.map((item, i) => ({ key: String(i), value: item }));
+		return {
+			kind: 'array',
+			isContainer: entries.length > 0,
+			preview: entries.length > 0 ? `[${entries.length}]` : '[]',
+			entries
+		};
+	}
+	if (typeof value === 'object') {
+		const entries: JsonEntry[] = Object.entries(value as Record<string, unknown>).map(
+			([key, v]) => ({ key, value: v })
+		);
+		return {
+			kind: 'object',
+			isContainer: entries.length > 0,
+			preview: entries.length > 0 ? '{…}' : '{}',
+			entries
+		};
+	}
+	if (typeof value === 'number') {
+		return { kind: 'number', isContainer: false, preview: String(value), entries: [] };
+	}
+	if (typeof value === 'boolean') {
+		return { kind: 'boolean', isContainer: false, preview: value ? 'true' : 'false', entries: [] };
+	}
+	// string (and any other primitive) → rendered as-is
+	return { kind: 'string', isContainer: false, preview: String(value), entries: [] };
+}

--- a/services/ui-neu/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/services/ui-neu/frontend/src/routes/jobs/[id]/+page.svelte
@@ -16,7 +16,7 @@
 	import JobLifecycle from '$lib/components/JobLifecycle.svelte';
 	import { effectiveJobStatus, isPartialComplete } from '$lib/utils/job-status';
 	import { discTypeLabel, isJobActive } from '$lib/utils/job-type';
-	import { buildMetadataFields } from '$lib/utils/job-fields';
+	import { buildMetadataFields, metadataEntries } from '$lib/utils/job-fields';
 	import { extractMusicTracks } from '$lib/utils/music-tracks';
 	import { trackKindLabel, trackSizeLabel } from '$lib/utils/track-fields';
 	import LoadState from '$lib/components/LoadState.svelte';
@@ -91,6 +91,8 @@
 
 	let metadataFields = $derived(detail ? buildMetadataFields(detail.job) : []);
 	let musicTracks = $derived(detail ? extractMusicTracks(detail.job.metadata_json) : []);
+	let showRawMetadata = $state(false);
+	let rawMetadataEntries = $derived(detail ? metadataEntries(detail.job.metadata_json) : []);
 
 	const panelTabBase = 'flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15';
 	const panelTabActive = 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10';
@@ -474,6 +476,42 @@
 						</tbody>
 					</table>
 				</div>
+			</section>
+		{/if}
+
+		<!-- Raw metadata (collapsible): the full metadata_json, nothing hidden -->
+		{#if rawMetadataEntries.length > 0}
+			<section>
+				<button
+					type="button"
+					onclick={() => { showRawMetadata = !showRawMetadata; }}
+					class="flex w-full items-center gap-2 text-lg font-semibold text-gray-900 dark:text-white"
+				>
+					<svg class="h-4 w-4 transition-transform {showRawMetadata ? 'rotate-90' : ''}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+					</svg>
+					Raw metadata
+				</button>
+				{#if showRawMetadata}
+					<div class="mt-3 overflow-x-auto rounded-lg border border-primary/20 dark:border-primary/20">
+						<table class="w-full text-left text-sm">
+							<tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+								{#each rawMetadataEntries as entry}
+									<tr class="align-top hover:bg-page dark:hover:bg-gray-800/50">
+										<td class="px-4 py-2 font-mono text-xs font-medium text-gray-500 dark:text-gray-400 whitespace-nowrap">{entry.key}</td>
+										<td class="px-4 py-2 text-gray-900 dark:text-white">
+											{#if entry.isJson}
+												<pre class="font-mono text-xs whitespace-pre-wrap">{entry.display}</pre>
+											{:else}
+												<span class="font-mono text-xs">{entry.display}</span>
+											{/if}
+										</td>
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
+				{/if}
 			</section>
 		{/if}
 	</div>

--- a/services/ui-neu/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/services/ui-neu/frontend/src/routes/jobs/[id]/+page.svelte
@@ -16,11 +16,12 @@
 	import JobLifecycle from '$lib/components/JobLifecycle.svelte';
 	import { effectiveJobStatus, isPartialComplete } from '$lib/utils/job-status';
 	import { discTypeLabel, isJobActive } from '$lib/utils/job-type';
-	import { buildMetadataFields, metadataEntries, readJobMetadata } from '$lib/utils/job-fields';
+	import { buildMetadataFields, readJobMetadata } from '$lib/utils/job-fields';
 	import { extractMusicTracks } from '$lib/utils/music-tracks';
 	import { trackKindLabel, trackSizeLabel } from '$lib/utils/track-fields';
 	import LoadState from '$lib/components/LoadState.svelte';
 	import SkeletonCard from '$lib/components/SkeletonCard.svelte';
+	import JsonTree from '$lib/components/JsonTree.svelte';
 
 	let detail = $state<JobDetailView | null>(null);
 	let jobLoading = $state(true);
@@ -96,7 +97,9 @@
 	);
 	let jobMeta = $derived(detail ? readJobMetadata(detail.job.metadata_json) : {});
 	let showRawMetadata = $state(false);
-	let rawMetadataEntries = $derived(detail ? metadataEntries(detail.job.metadata_json) : []);
+	let rawMetadataPairs = $derived(
+		detail ? Object.entries((detail.job.metadata_json ?? {}) as Record<string, unknown>) : []
+	);
 
 	const panelTabBase = 'flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15';
 	const panelTabActive = 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10';
@@ -520,8 +523,8 @@
 			</section>
 		{/if}
 
-		<!-- Raw metadata (collapsible): the full metadata_json, nothing hidden -->
-		{#if rawMetadataEntries.length > 0}
+		<!-- Raw metadata (collapsible): the full metadata_json as a JSON tree, nothing hidden -->
+		{#if rawMetadataPairs.length > 0}
 			<section>
 				<button
 					type="button"
@@ -534,23 +537,10 @@
 					Raw metadata
 				</button>
 				{#if showRawMetadata}
-					<div class="mt-3 overflow-x-auto rounded-lg border border-primary/20 dark:border-primary/20">
-						<table class="w-full text-left text-sm">
-							<tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-								{#each rawMetadataEntries as entry}
-									<tr class="align-top hover:bg-page dark:hover:bg-gray-800/50">
-										<td class="px-4 py-2 font-mono text-xs font-medium text-gray-500 dark:text-gray-400 whitespace-nowrap">{entry.key}</td>
-										<td class="px-4 py-2 text-gray-900 dark:text-white">
-											{#if entry.isJson}
-												<pre class="font-mono text-xs whitespace-pre-wrap">{entry.display}</pre>
-											{:else}
-												<span class="font-mono text-xs">{entry.display}</span>
-											{/if}
-										</td>
-									</tr>
-								{/each}
-							</tbody>
-						</table>
+					<div class="mt-3 overflow-x-auto rounded-lg border border-primary/20 p-3 dark:border-primary/20">
+						{#each rawMetadataPairs as [key, value]}
+							<JsonTree {value} name={key} depth={0} />
+						{/each}
 					</div>
 				{/if}
 			</section>

--- a/services/ui-neu/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/services/ui-neu/frontend/src/routes/jobs/[id]/+page.svelte
@@ -91,6 +91,9 @@
 
 	let metadataFields = $derived(detail ? buildMetadataFields(detail.job) : []);
 	let musicTracks = $derived(detail ? extractMusicTracks(detail.job.metadata_json) : []);
+	let tracksAreSeries = $derived(
+		(detail?.tracks ?? []).some((t) => t.video_type === 'series' || t.episode_number != null)
+	);
 	let showRawMetadata = $state(false);
 	let rawMetadataEntries = $derived(detail ? metadataEntries(detail.job.metadata_json) : []);
 
@@ -332,6 +335,9 @@
 								<th class="px-4 py-3 font-medium">#</th>
 								<th class="px-4 py-3 font-medium">Kind</th>
 								<th class="px-4 py-3 font-medium">Title</th>
+								{#if tracksAreSeries}
+									<th class="px-4 py-3 font-medium">Episode</th>
+								{/if}
 								<th class="px-4 py-3 font-medium">Filename</th>
 								<th class="px-4 py-3 font-medium">Length</th>
 								<th class="px-4 py-3 font-medium">Size</th>
@@ -360,12 +366,35 @@
 													{#if track.year}
 														<span class="text-gray-400"> ({track.year})</span>
 													{/if}
+													<div class="mt-0.5 flex flex-wrap items-center gap-1">
+														{#if track.imdb_id}
+															<a href="https://www.imdb.com/title/{track.imdb_id}" target="_blank" rel="noopener noreferrer" onclick={(e) => e.stopPropagation()} class="rounded-full bg-yellow-400 px-1.5 py-0.5 text-[9px] font-bold text-black">IMDb</a>
+														{/if}
+														{#if track.edition}
+															<span class="rounded-sm bg-primary/10 px-1.5 py-0.5 text-[9px] font-medium text-gray-600 dark:bg-primary/15 dark:text-gray-300">{track.edition}</span>
+														{/if}
+														{#if track.role}
+															<span class="rounded-sm bg-primary/10 px-1.5 py-0.5 text-[9px] font-medium text-gray-600 dark:bg-primary/15 dark:text-gray-300">{track.role}</span>
+														{/if}
+													</div>
 												</div>
 											</div>
 										{:else}
 											<span class="text-xs text-gray-400">{job.title || 'Untitled'}{#if job.year} ({job.year}){/if}</span>
 										{/if}
 									</td>
+									{#if tracksAreSeries}
+										<td class="px-4 py-3" data-label="Episode">
+											{#if track.episode_number != null}
+												<span class="font-medium text-gray-900 dark:text-white">{track.episode_number}</span>
+												{#if track.episode_name}
+													<span class="ml-1.5 text-xs text-gray-500 dark:text-gray-400">{track.episode_name}</span>
+												{/if}
+											{:else}
+												<span class="text-gray-400">—</span>
+											{/if}
+										</td>
+									{/if}
 									<td class="max-w-[260px] truncate px-4 py-3 font-mono text-xs text-gray-700 dark:text-gray-300" data-label="Filename" title={preview?.output_name ?? ''}>
 										{#if preview?.output_name}
 											<span>{preview.output_name}</span>

--- a/services/ui-neu/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/services/ui-neu/frontend/src/routes/jobs/[id]/+page.svelte
@@ -16,7 +16,7 @@
 	import JobLifecycle from '$lib/components/JobLifecycle.svelte';
 	import { effectiveJobStatus, isPartialComplete } from '$lib/utils/job-status';
 	import { discTypeLabel, isJobActive } from '$lib/utils/job-type';
-	import { buildMetadataFields, metadataEntries } from '$lib/utils/job-fields';
+	import { buildMetadataFields, metadataEntries, readJobMetadata } from '$lib/utils/job-fields';
 	import { extractMusicTracks } from '$lib/utils/music-tracks';
 	import { trackKindLabel, trackSizeLabel } from '$lib/utils/track-fields';
 	import LoadState from '$lib/components/LoadState.svelte';
@@ -94,6 +94,7 @@
 	let tracksAreSeries = $derived(
 		(detail?.tracks ?? []).some((t) => t.video_type === 'series' || t.episode_number != null)
 	);
+	let jobMeta = $derived(detail ? readJobMetadata(detail.job.metadata_json) : {});
 	let showRawMetadata = $state(false);
 	let rawMetadataEntries = $derived(detail ? metadataEntries(detail.job.metadata_json) : []);
 
@@ -234,6 +235,17 @@
 					<span class="text-base text-gray-400 dark:text-gray-500">({job.year})</span>
 				{/if}
 				<StatusBadge status={effectiveJobStatus(job)} />
+				{#if jobMeta.imdb_id && !isCdDisc}
+					<a href="https://www.imdb.com/title/{jobMeta.imdb_id}" target="_blank" rel="noopener noreferrer" class="rounded-full bg-yellow-400 px-2.5 py-0.5 text-[10px] font-bold text-black">IMDb</a>
+				{/if}
+				{#if jobMeta.multi_title}
+					<span class="rounded-full bg-purple-100 px-2.5 py-0.5 text-[10px] font-semibold uppercase text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">Multi-Title</span>
+				{/if}
+				{#if jobMeta.source_type === 'iso'}
+					<span class="rounded-sm bg-violet-100 px-2 py-0.5 text-[10px] font-medium text-violet-700 dark:bg-violet-900/30 dark:text-violet-400">ISO</span>
+				{:else if jobMeta.source_type === 'folder'}
+					<span class="rounded-sm bg-violet-100 px-2 py-0.5 text-[10px] font-medium text-violet-700 dark:bg-violet-900/30 dark:text-violet-400">Folder</span>
+				{/if}
 
 				<!-- Action buttons pushed right -->
 				<div class="flex flex-wrap items-center gap-2 ml-auto">

--- a/services/ui-neu/frontend/src/routes/jobs/[id]/page.test.ts
+++ b/services/ui-neu/frontend/src/routes/jobs/[id]/page.test.ts
@@ -335,4 +335,57 @@ describe('Job detail page (v3)', () => {
 		await waitFor(() => expect(screen.getByText('Tracks (1)')).toBeInTheDocument());
 		expect(screen.getByText("Director's Cut")).toBeInTheDocument();
 	});
+
+	it('renders IMDb, Multi-Title, and Source badges in the title bar when present', async () => {
+		mockFetchJob.mockResolvedValue({
+			job: createJob({
+				id: 'job_42',
+				title: 'Test Movie',
+				status: 'ripped',
+				disc_type: 'bluray',
+				metadata_json: { imdb_id: 'tt7777777', multi_title: true, source_type: 'iso' }
+			}),
+			tracks: [],
+			fingerprints: []
+		});
+		renderComponent(Page);
+		await waitFor(() => expect(screen.getByRole('heading', { name: 'Test Movie' })).toBeInTheDocument());
+		// IMDb appears both as a grid link and a header pill — at least one link to the title page.
+		const imdbLinks = screen.getAllByRole('link', { name: 'IMDb' });
+		expect(imdbLinks.some((a) => a.getAttribute('href') === 'https://www.imdb.com/title/tt7777777')).toBe(true);
+		expect(screen.getByText('Multi-Title')).toBeInTheDocument();
+		expect(screen.getByText('ISO')).toBeInTheDocument();
+	});
+
+	it('omits header badges when metadata_json lacks them', async () => {
+		// explicit empty metadata_json — no badge data present
+		mockFetchJob.mockResolvedValue({
+			job: createJob({ id: 'job_42', title: 'Test Movie', status: 'ripped', disc_type: 'bluray', metadata_json: {} }),
+			tracks: [],
+			fingerprints: []
+		});
+		renderComponent(Page);
+		await waitFor(() => expect(screen.getByRole('heading', { name: 'Test Movie' })).toBeInTheDocument());
+		expect(screen.queryByText('Multi-Title')).not.toBeInTheDocument();
+		expect(screen.queryByText('ISO')).not.toBeInTheDocument();
+		expect(screen.queryByText('Folder')).not.toBeInTheDocument();
+	});
+
+	it('does not show the IMDb header pill for a music disc', async () => {
+		mockFetchJob.mockResolvedValue({
+			job: createJob({
+				id: 'job_42',
+				title: 'Abbey Road',
+				status: 'ripped',
+				disc_type: 'cd',
+				metadata_json: { imdb_id: 'tt0000000' }
+			}),
+			tracks: [],
+			fingerprints: []
+		});
+		renderComponent(Page);
+		await waitFor(() => expect(screen.getByRole('heading', { name: 'Abbey Road' })).toBeInTheDocument());
+		// No IMDb pill/link for music (grid also suppresses it via not-music gate in neu; here disc_type cd).
+		expect(screen.queryByRole('link', { name: 'IMDb' })).not.toBeInTheDocument();
+	});
 });

--- a/services/ui-neu/frontend/src/routes/jobs/[id]/page.test.ts
+++ b/services/ui-neu/frontend/src/routes/jobs/[id]/page.test.ts
@@ -271,4 +271,68 @@ describe('Job detail page (v3)', () => {
 		await waitFor(() => expect(screen.getByRole('heading', { name: 'Bare' })).toBeInTheDocument());
 		expect(screen.queryByRole('button', { name: 'Raw metadata' })).not.toBeInTheDocument();
 	});
+
+	it('renders a track poster thumbnail and IMDb link when present', async () => {
+		mockFetchJob.mockResolvedValue({
+			job: createJob({ id: 'job_42', title: 'Test Movie', status: 'ripped' }),
+			tracks: [
+				createTrack({
+					id: 'trk_1',
+					status: 'done',
+					title: 'Feature',
+					imdb_id: 'tt5555555',
+					poster_url: 'https://example.test/p.jpg'
+				})
+			],
+			fingerprints: []
+		});
+		renderComponent(Page);
+		await waitFor(() => expect(screen.getByText('Tracks (1)')).toBeInTheDocument());
+		const imdb = screen.getByRole('link', { name: 'IMDb' });
+		expect(imdb.getAttribute('href')).toBe('https://www.imdb.com/title/tt5555555');
+		expect(document.querySelector('img[src="/api/images/proxy?url=https%3A%2F%2Fexample.test%2Fp.jpg"]')).not.toBeNull();
+	});
+
+	it('renders an Episode column only when a track is a series', async () => {
+		mockFetchJob.mockResolvedValue({
+			job: createJob({ id: 'job_42', title: 'Show', status: 'ripped' }),
+			tracks: [
+				createTrack({
+					id: 'trk_1',
+					status: 'done',
+					video_type: 'series',
+					episode_number: 3,
+					episode_name: 'The One With The Test'
+				})
+			],
+			fingerprints: []
+		});
+		renderComponent(Page);
+		await waitFor(() => expect(screen.getByText('Tracks (1)')).toBeInTheDocument());
+		expect(screen.getByRole('columnheader', { name: 'Episode' })).toBeInTheDocument();
+		expect(screen.getByText('The One With The Test')).toBeInTheDocument();
+	});
+
+	it('omits the Episode column for non-series tracks', async () => {
+		// default mockFetchJob: one non-series track
+		mockFetchJob.mockResolvedValue({
+			job: createJob({ id: 'job_42', title: 'Test Movie', status: 'ripped' }),
+			tracks: [createTrack({ id: 'trk_1', status: 'done' })],
+			fingerprints: []
+		});
+		renderComponent(Page);
+		await waitFor(() => expect(screen.getByText('Tracks (1)')).toBeInTheDocument());
+		expect(screen.queryByRole('columnheader', { name: 'Episode' })).not.toBeInTheDocument();
+	});
+
+	it('renders an edition badge when set', async () => {
+		mockFetchJob.mockResolvedValue({
+			job: createJob({ id: 'job_42', title: 'Test Movie', status: 'ripped' }),
+			tracks: [createTrack({ id: 'trk_1', status: 'done', title: 'Feature', edition: "Director's Cut" })],
+			fingerprints: []
+		});
+		renderComponent(Page);
+		await waitFor(() => expect(screen.getByText('Tracks (1)')).toBeInTheDocument());
+		expect(screen.getByText("Director's Cut")).toBeInTheDocument();
+	});
 });

--- a/services/ui-neu/frontend/src/routes/jobs/[id]/page.test.ts
+++ b/services/ui-neu/frontend/src/routes/jobs/[id]/page.test.ts
@@ -237,4 +237,38 @@ describe('Job detail page (v3)', () => {
 		});
 		expect(screen.getByText('Opening')).toBeInTheDocument();
 	});
+
+	it('renders a collapsible Raw metadata section that reveals the blob', async () => {
+		mockFetchJob.mockResolvedValue({
+			job: createJob({
+				id: 'job_42',
+				title: 'Test Movie',
+				status: 'ripped',
+				metadata_json: { imdb_id: 'tt9999999', scan_result: { titles: [{ index: 0 }] } }
+			}),
+			tracks: [],
+			fingerprints: []
+		});
+		renderComponent(Page);
+
+		const toggle = await screen.findByRole('button', { name: 'Raw metadata' });
+		// Collapsed initially: the raw key not yet shown.
+		expect(screen.queryByText('scan_result')).not.toBeInTheDocument();
+		await fireEvent.click(toggle);
+		await waitFor(() => {
+			expect(screen.getByText('scan_result')).toBeInTheDocument();
+			expect(screen.getByText('imdb_id')).toBeInTheDocument();
+		});
+	});
+
+	it('omits the Raw metadata section when metadata_json is empty', async () => {
+		mockFetchJob.mockResolvedValue({
+			job: createJob({ id: 'job_42', title: 'Bare', status: 'ripped', metadata_json: {} }),
+			tracks: [],
+			fingerprints: []
+		});
+		renderComponent(Page);
+		await waitFor(() => expect(screen.getByRole('heading', { name: 'Bare' })).toBeInTheDocument());
+		expect(screen.queryByRole('button', { name: 'Raw metadata' })).not.toBeInTheDocument();
+	});
 });

--- a/services/ui-neu/frontend/src/routes/jobs/[id]/page.test.ts
+++ b/services/ui-neu/frontend/src/routes/jobs/[id]/page.test.ts
@@ -238,7 +238,7 @@ describe('Job detail page (v3)', () => {
 		expect(screen.getByText('Opening')).toBeInTheDocument();
 	});
 
-	it('renders a collapsible Raw metadata section that reveals the blob', async () => {
+	it('renders the Raw metadata as a collapsible JSON tree', async () => {
 		mockFetchJob.mockResolvedValue({
 			job: createJob({
 				id: 'job_42',
@@ -252,12 +252,15 @@ describe('Job detail page (v3)', () => {
 		renderComponent(Page);
 
 		const toggle = await screen.findByRole('button', { name: 'Raw metadata' });
-		// Collapsed initially: the raw key not yet shown.
+		// Collapsed initially: the top-level keys are not yet shown.
 		expect(screen.queryByText('scan_result')).not.toBeInTheDocument();
 		await fireEvent.click(toggle);
 		await waitFor(() => {
-			expect(screen.getByText('scan_result')).toBeInTheDocument();
+			// Top-level keys render as tree node names.
 			expect(screen.getByText('imdb_id')).toBeInTheDocument();
+			expect(screen.getByText('scan_result')).toBeInTheDocument();
+			// scan_result is open one level (depth 1) → its child "titles" disclosure shows.
+			expect(screen.getByText('titles')).toBeInTheDocument();
 		});
 	});
 


### PR DESCRIPTION
Detail page surfaces all available metadata: promoted grid fields, IMDb/Multi-Title/Source header badges, richer track cells (poster/IMDb/edition + Episode), and a recursive collapsible JsonTree for the full metadata_json. Stacks on Tier-21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)