### PR TITLE
fix: installer PUID/PGID hardening + eject on abandon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,18 @@ jobs:
           fi
           shellcheck "${files[@]}"
 
+  test-shell:
+    name: test (shell — plain-bash suites)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      # Zero-infra unit tests that source the production scripts via their
+      # *_SOURCE_ONLY seams — no docker, no root, <1s each. Un-run tests rot.
+      - name: Entrypoint writability-guard suite
+        run: bash services/_common/test-entrypoint-guard.sh
+      - name: Installer PUID/PGID suite
+        run: bash devtools/test-install-env.sh
+
   test-python:
     name: test (python — pytest)
     runs-on: ubuntu-latest

--- a/devtools/test-install-env.sh
+++ b/devtools/test-install-env.sh
@@ -91,7 +91,9 @@ check "resolve rejects PGID=0" 1 "$rc"
 PREFIX="$TMP/fresh"
 mkdir -p "$PREFIX"
 PUID="" PGID="" resolve_puid_pgid
-seed_env >/dev/null
+log_out="$(seed_env)"
+check "fresh seed log states PUID:PGID" "yes" \
+    "$( [[ "$log_out" == *"PUID:PGID ${MY_UID}:${MY_GID}"* ]] && echo yes || echo no )"
 check "fresh seed PUID" "$MY_UID" "$(env_get "$PREFIX/.env" PUID)"
 check "fresh seed PGID" "$MY_GID" "$(env_get "$PREFIX/.env" PGID)"
 check "fresh seed has secrets" "yes" "$( [[ -n "$(env_get "$PREFIX/.env" ARM_SERVICE_TOKEN)" ]] && echo yes || echo no )"
@@ -110,7 +112,9 @@ ARM_GPUS=[]
 ARM_RENDER_GID=
 EOF
 PUID="" PGID="" resolve_puid_pgid
-seed_env >/dev/null
+log_out="$(seed_env)"
+check "rerun log states the preserved values" "yes" \
+    "$( [[ "$log_out" == *"preserving secrets + PUID/PGID 1001:1000"* ]] && echo yes || echo no )"
 check "rerun preserves hand-set PUID" "1001" "$(env_get "$PREFIX/.env" PUID)"
 check "rerun preserves hand-set PGID" "1000" "$(env_get "$PREFIX/.env" PGID)"
 check "rerun preserves secrets" "keepme" "$(env_get "$PREFIX/.env" POSTGRES_PASSWORD)"

--- a/devtools/test-install-env.sh
+++ b/devtools/test-install-env.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Plain-bash unit test for install.sh's PUID/PGID handling.
+# No bats — the repo gates shell with shellcheck only. Runs with no Docker,
+# no root: it sources install.sh (via ARM_INSTALL_SOURCE_ONLY) and drives
+# require_unprivileged / resolve_puid_pgid / seed_env against a temp prefix.
+#
+# Covers the deploy-test regression: running the installer under sudo seeded
+# PUID/PGID=0:0 (container groupadd --gid 0 collides with the root group), and
+# re-runs sed-clobbered hand-fixed values back to the broken derivation.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL="${HERE}/../install.sh"
+
+# Fail fast if the source-only seam is missing: sourcing without it would run
+# main() — prereq checks, cert generation, a GitHub API call — on this machine.
+if ! grep -q 'ARM_INSTALL_SOURCE_ONLY' "$INSTALL"; then
+    echo "FAIL - install.sh has no ARM_INSTALL_SOURCE_ONLY seam; refusing to source it" >&2
+    exit 1
+fi
+
+export ARM_INSTALL_SOURCE_ONLY=1
+# shellcheck disable=SC1090
+source "$INSTALL"
+
+# seed_env probes host GPUs via docker; stub the probes out.
+# shellcheck disable=SC2329  # invoked indirectly by the sourced seed_env
+detect_gpus() { printf '[]'; }
+# shellcheck disable=SC2329  # invoked indirectly by the sourced seed_env
+detect_render_gid() { printf ''; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+check() {  # check <label> <expected> <actual>
+    local label="$1" want="$2" got="$3"
+    if [[ "$want" == "$got" ]]; then
+        echo "ok   - ${label}"
+    else
+        echo "FAIL - ${label}: expected '${want}', got '${got}'" >&2
+        fail=1
+    fi
+}
+
+env_get() {  # env_get <file> <key>
+    sed -nE "s/^$2=(.*)$/\1/p" "$1" | head -n1
+}
+
+MY_UID="$(id -u)"
+MY_GID="$(id -g)"
+
+# --- require_unprivileged ----------------------------------------------------
+
+# 1. Normal unprivileged run passes.
+rc=0; ( INSTALL_EUID="$MY_UID" require_unprivileged ) >/dev/null 2>&1 || rc=$?
+check "unprivileged run accepted" 0 "$rc"
+
+# 2. Root without explicit PUID/PGID is refused (the sudo footgun).
+rc=0; ( INSTALL_EUID=0 PUID="" PGID="" require_unprivileged ) >/dev/null 2>&1 || rc=$?
+check "root run refused" 1 "$rc"
+
+# 3. Root with a valid explicit PUID/PGID is allowed (unattended escape hatch).
+rc=0; ( INSTALL_EUID=0 PUID=1000 PGID=1000 require_unprivileged ) >/dev/null 2>&1 || rc=$?
+check "root + explicit PUID/PGID accepted" 0 "$rc"
+
+# 4. Root with an explicit 0 is still refused — 0 is never a valid gosu target.
+rc=0; ( INSTALL_EUID=0 PUID=0 PGID=0 require_unprivileged ) >/dev/null 2>&1 || rc=$?
+check "root + explicit 0:0 refused" 1 "$rc"
+
+# --- resolve_puid_pgid ---------------------------------------------------------
+
+# 5. Defaults to the invoking user.
+got="$( PUID="" PGID="" resolve_puid_pgid; printf '%s:%s' "$ARM_PUID" "$ARM_PGID" )"
+check "resolve defaults to id -u:id -g" "${MY_UID}:${MY_GID}" "$got"
+
+# 6. Env override wins.
+got="$( PUID=1234 PGID=4321 resolve_puid_pgid; printf '%s:%s' "$ARM_PUID" "$ARM_PGID" )"
+check "resolve honors PUID/PGID env override" "1234:4321" "$got"
+
+# 7. Non-numeric override is rejected.
+rc=0; ( PUID=abc PGID=1000 resolve_puid_pgid ) >/dev/null 2>&1 || rc=$?
+check "resolve rejects non-numeric PUID" 1 "$rc"
+
+# 8. Zero override is rejected.
+rc=0; ( PUID=1000 PGID=0 resolve_puid_pgid ) >/dev/null 2>&1 || rc=$?
+check "resolve rejects PGID=0" 1 "$rc"
+
+# --- seed_env: fresh install ---------------------------------------------------
+
+PREFIX="$TMP/fresh"
+mkdir -p "$PREFIX"
+PUID="" PGID="" resolve_puid_pgid
+seed_env >/dev/null
+check "fresh seed PUID" "$MY_UID" "$(env_get "$PREFIX/.env" PUID)"
+check "fresh seed PGID" "$MY_GID" "$(env_get "$PREFIX/.env" PGID)"
+check "fresh seed has secrets" "yes" "$( [[ -n "$(env_get "$PREFIX/.env" ARM_SERVICE_TOKEN)" ]] && echo yes || echo no )"
+
+# --- seed_env: re-run preserves operator-set PUID/PGID -------------------------
+
+PREFIX="$TMP/rerun"
+mkdir -p "$PREFIX"
+cat > "$PREFIX/.env" <<'EOF'
+POSTGRES_PASSWORD=keepme
+ARM_SERVICE_TOKEN=keepme-too
+PUID=1001
+PGID=1000
+CDROM_GID=99
+ARM_GPUS=[]
+ARM_RENDER_GID=
+EOF
+PUID="" PGID="" resolve_puid_pgid
+seed_env >/dev/null
+check "rerun preserves hand-set PUID" "1001" "$(env_get "$PREFIX/.env" PUID)"
+check "rerun preserves hand-set PGID" "1000" "$(env_get "$PREFIX/.env" PGID)"
+check "rerun preserves secrets" "keepme" "$(env_get "$PREFIX/.env" POSTGRES_PASSWORD)"
+check "rerun still re-derives CDROM_GID" "yes" "$( [[ "$(env_get "$PREFIX/.env" CDROM_GID)" != "99" ]] && echo yes || echo no )"
+
+# --- seed_env: re-run heals a broken 0:0 seed ----------------------------------
+
+PREFIX="$TMP/heal"
+mkdir -p "$PREFIX"
+cat > "$PREFIX/.env" <<'EOF'
+POSTGRES_PASSWORD=keepme
+PUID=0
+PGID=0
+CDROM_GID=44
+EOF
+PUID="" PGID="" resolve_puid_pgid
+seed_env >/dev/null 2>&1
+check "rerun heals PUID=0" "$MY_UID" "$(env_get "$PREFIX/.env" PUID)"
+check "rerun heals PGID=0" "$MY_GID" "$(env_get "$PREFIX/.env" PGID)"
+
+# --- seed_env: explicit env override beats existing .env values ----------------
+
+PREFIX="$TMP/override"
+mkdir -p "$PREFIX"
+cat > "$PREFIX/.env" <<'EOF'
+POSTGRES_PASSWORD=keepme
+PUID=1001
+PGID=1000
+CDROM_GID=44
+EOF
+PUID=2000 PGID=2000 resolve_puid_pgid
+seed_env >/dev/null
+check "rerun explicit override wins over .env" "2000:2000" \
+    "$(env_get "$PREFIX/.env" PUID):$(env_get "$PREFIX/.env" PGID)"
+
+# --- seed_env: missing PUID/PGID lines get appended, not lost ------------------
+
+PREFIX="$TMP/missing"
+mkdir -p "$PREFIX"
+cat > "$PREFIX/.env" <<'EOF'
+POSTGRES_PASSWORD=keepme
+CDROM_GID=44
+EOF
+PUID="" PGID="" resolve_puid_pgid
+seed_env >/dev/null 2>&1
+check "rerun appends missing PUID" "$MY_UID" "$(env_get "$PREFIX/.env" PUID)"
+check "rerun appends missing PGID" "$MY_GID" "$(env_get "$PREFIX/.env" PGID)"
+
+exit "$fail"

--- a/devtools/test-install-env.sh
+++ b/devtools/test-install-env.sh
@@ -12,6 +12,13 @@ set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL="${HERE}/../install.sh"
 
+# The suite exercises the non-root derivation paths (fresh seed / heal expect
+# id -u/id -g to be valid container ids). A root runner would fail them all.
+if [[ "$(id -u)" -eq 0 ]]; then
+    echo "SKIP: test-install-env.sh must run as a non-root user"
+    exit 0
+fi
+
 # Fail fast if the source-only seam is missing: sourcing without it would run
 # main() — prereq checks, cert generation, a GitHub API call — on this machine.
 if ! grep -q 'ARM_INSTALL_SOURCE_ONLY' "$INSTALL"; then
@@ -24,9 +31,9 @@ export ARM_INSTALL_SOURCE_ONLY=1
 source "$INSTALL"
 
 # seed_env probes host GPUs via docker; stub the probes out.
-# shellcheck disable=SC2329  # invoked indirectly by the sourced seed_env
+# shellcheck disable=SC2329,SC2317  # invoked indirectly by the sourced seed_env
 detect_gpus() { printf '[]'; }
-# shellcheck disable=SC2329  # invoked indirectly by the sourced seed_env
+# shellcheck disable=SC2329,SC2317  # invoked indirectly by the sourced seed_env
 detect_render_gid() { printf ''; }
 
 TMP="$(mktemp -d)"
@@ -53,19 +60,19 @@ MY_GID="$(id -g)"
 # --- require_unprivileged ----------------------------------------------------
 
 # 1. Normal unprivileged run passes.
-rc=0; ( INSTALL_EUID="$MY_UID" require_unprivileged ) >/dev/null 2>&1 || rc=$?
+rc=0; ( ARM_INSTALL_EUID="$MY_UID" require_unprivileged ) >/dev/null 2>&1 || rc=$?
 check "unprivileged run accepted" 0 "$rc"
 
 # 2. Root without explicit PUID/PGID is refused (the sudo footgun).
-rc=0; ( INSTALL_EUID=0 PUID="" PGID="" require_unprivileged ) >/dev/null 2>&1 || rc=$?
+rc=0; ( ARM_INSTALL_EUID=0 PUID="" PGID="" require_unprivileged ) >/dev/null 2>&1 || rc=$?
 check "root run refused" 1 "$rc"
 
 # 3. Root with a valid explicit PUID/PGID is allowed (unattended escape hatch).
-rc=0; ( INSTALL_EUID=0 PUID=1000 PGID=1000 require_unprivileged ) >/dev/null 2>&1 || rc=$?
+rc=0; ( ARM_INSTALL_EUID=0 PUID=1000 PGID=1000 require_unprivileged ) >/dev/null 2>&1 || rc=$?
 check "root + explicit PUID/PGID accepted" 0 "$rc"
 
 # 4. Root with an explicit 0 is still refused — 0 is never a valid gosu target.
-rc=0; ( INSTALL_EUID=0 PUID=0 PGID=0 require_unprivileged ) >/dev/null 2>&1 || rc=$?
+rc=0; ( ARM_INSTALL_EUID=0 PUID=0 PGID=0 require_unprivileged ) >/dev/null 2>&1 || rc=$?
 check "root + explicit 0:0 refused" 1 "$rc"
 
 # --- resolve_puid_pgid ---------------------------------------------------------
@@ -86,6 +93,10 @@ check "resolve rejects non-numeric PUID" 1 "$rc"
 rc=0; ( PUID=1000 PGID=0 resolve_puid_pgid ) >/dev/null 2>&1 || rc=$?
 check "resolve rejects PGID=0" 1 "$rc"
 
+# 9. Leading-zero override is rejected (useradd/groupadd would re-parse it).
+rc=0; ( PUID=010 PGID=1000 resolve_puid_pgid ) >/dev/null 2>&1 || rc=$?
+check "resolve rejects leading-zero PUID" 1 "$rc"
+
 # --- seed_env: fresh install ---------------------------------------------------
 
 PREFIX="$TMP/fresh"
@@ -100,13 +111,15 @@ check "fresh seed has secrets" "yes" "$( [[ -n "$(env_get "$PREFIX/.env" ARM_SER
 
 # --- seed_env: re-run preserves operator-set PUID/PGID -------------------------
 
+# 2345:6789 are arbitrary fixture values — deliberately unlike any real host's
+# ids, so nobody mistakes them for a supported default.
 PREFIX="$TMP/rerun"
 mkdir -p "$PREFIX"
 cat > "$PREFIX/.env" <<'EOF'
 POSTGRES_PASSWORD=keepme
 ARM_SERVICE_TOKEN=keepme-too
-PUID=1001
-PGID=1000
+PUID=2345
+PGID=6789
 CDROM_GID=99
 ARM_GPUS=[]
 ARM_RENDER_GID=
@@ -114,9 +127,9 @@ EOF
 PUID="" PGID="" resolve_puid_pgid
 log_out="$(seed_env)"
 check "rerun log states the preserved values" "yes" \
-    "$( [[ "$log_out" == *"preserving secrets + PUID/PGID 1001:1000"* ]] && echo yes || echo no )"
-check "rerun preserves hand-set PUID" "1001" "$(env_get "$PREFIX/.env" PUID)"
-check "rerun preserves hand-set PGID" "1000" "$(env_get "$PREFIX/.env" PGID)"
+    "$( [[ "$log_out" == *"preserving secrets + PUID/PGID 2345:6789"* ]] && echo yes || echo no )"
+check "rerun preserves hand-set PUID" "2345" "$(env_get "$PREFIX/.env" PUID)"
+check "rerun preserves hand-set PGID" "6789" "$(env_get "$PREFIX/.env" PGID)"
 check "rerun preserves secrets" "keepme" "$(env_get "$PREFIX/.env" POSTGRES_PASSWORD)"
 check "rerun still re-derives CDROM_GID" "yes" "$( [[ "$(env_get "$PREFIX/.env" CDROM_GID)" != "99" ]] && echo yes || echo no )"
 
@@ -141,8 +154,8 @@ PREFIX="$TMP/override"
 mkdir -p "$PREFIX"
 cat > "$PREFIX/.env" <<'EOF'
 POSTGRES_PASSWORD=keepme
-PUID=1001
-PGID=1000
+PUID=2345
+PGID=6789
 CDROM_GID=44
 EOF
 PUID=2000 PGID=2000 resolve_puid_pgid
@@ -162,5 +175,40 @@ PUID="" PGID="" resolve_puid_pgid
 seed_env >/dev/null 2>&1
 check "rerun appends missing PUID" "$MY_UID" "$(env_get "$PREFIX/.env" PUID)"
 check "rerun appends missing PGID" "$MY_GID" "$(env_get "$PREFIX/.env" PGID)"
+
+# --- seed_env: half-edited .env keeps its valid half ---------------------------
+
+PREFIX="$TMP/mixed"
+mkdir -p "$PREFIX"
+cat > "$PREFIX/.env" <<'EOF'
+POSTGRES_PASSWORD=keepme
+PUID=2345
+PGID=0
+EOF
+PUID="" PGID="" resolve_puid_pgid
+seed_env >/dev/null 2>&1
+check "mixed .env keeps valid PUID" "2345" "$(env_get "$PREFIX/.env" PUID)"
+check "mixed .env heals only broken PGID" "$MY_GID" "$(env_get "$PREFIX/.env" PGID)"
+check "mixed .env gets missing CDROM_GID appended" "yes" \
+    "$( [[ -n "$(env_get "$PREFIX/.env" CDROM_GID)" ]] && echo yes || echo no )"
+
+# --- seed_env: CRLF-edited .env values are sanitized, not clobbered ------------
+
+PREFIX="$TMP/crlf"
+mkdir -p "$PREFIX"
+printf 'POSTGRES_PASSWORD=keepme\nPUID=2345\r\nPGID=6789\r\nCDROM_GID=44\n' > "$PREFIX/.env"
+PUID="" PGID="" resolve_puid_pgid
+seed_env >/dev/null 2>&1
+check "CRLF .env keeps hand-set PUID" "2345" "$(env_get "$PREFIX/.env" PUID)"
+check "CRLF .env keeps hand-set PGID" "6789" "$(env_get "$PREFIX/.env" PGID)"
+
+# --- resolve: a non-root user whose PRIMARY GROUP is gid 0 must be rejected ----
+
+# Shadow `id` with a function (wins over the binary) — no production seam needed.
+# shellcheck disable=SC2329,SC2317  # invoked indirectly by the sourced resolve_puid_pgid
+id() { case "${1:-}" in -u) echo 1000 ;; -g) echo 0 ;; *) command id "$@" ;; esac; }
+rc=0; ( PUID="" PGID="" resolve_puid_pgid ) >/dev/null 2>&1 || rc=$?
+unset -f id
+check "resolve rejects derived primary gid 0" 1 "$rc"
 
 exit "$fail"

--- a/docs/arch/02-job-lifecycle.md
+++ b/docs/arch/02-job-lifecycle.md
@@ -44,7 +44,7 @@ Four long-lived entities drive the lifecycle, plus one reusable template:
                     (downstream session applications may queue)
 ```
 
-Terminal states for a `Job`: `ripped`, `ripped_partial`, `abandoned` (user gave up in UI), `failed` (identification failed catastrophically).
+Terminal states for a `Job`: `ripped`, `ripped_partial`, `abandoned` (user gave up in UI), `failed` (identification failed catastrophically). Abandoning also ejects the disc: the ripper's `job.abandoned` WS handler pops the tray when the abandoned job owns the drive's pipeline (ripping or parked) or when the drive sits idle with the disc still seated — a stale abandon while a different job's rip owns the drive never touches the tray.
 
 ## Track state machine
 

--- a/docs/arch/06-deployment.md
+++ b/docs/arch/06-deployment.md
@@ -266,6 +266,8 @@ curl -fsSL https://raw.githubusercontent.com/automatic-ripping-machine/automatic
 
 (Or `bash -c "$(curl -fsSL ...)"` for users who want a TTY; `install.sh --prefix /srv/arm` to override the default path.)
 
+**Run it as your regular user, never via `sudo`/root.** Containers drop privileges to the invoking user's uid:gid (`PUID`/`PGID`), and a root run would seed the unusable `0:0` (the entrypoint's `groupadd --gid 0` collides with the root group) plus root-own everything under a `/root/arm` prefix. The installer refuses to run as root; docker access should come from `docker` group membership (`sudo usermod -aG docker $USER && newgrp docker`). Unattended installs on root-only hosts can pass explicit non-root `PUID=`/`PGID=` env vars to bypass the guard.
+
 **What the installer does, in order:**
 
 1. **Prereq check.** `docker` ≥ 24, `docker compose` v2, `openssl` ≥ 1.1.1, `bash` ≥ 4. User is in the `docker` group (or `sudo` usable), and in the host's optical group. Fails fast with a clear message if anything is missing.
@@ -280,7 +282,7 @@ curl -fsSL https://raw.githubusercontent.com/automatic-ripping-machine/automatic
 
 **Idempotent rerun.** Re-running `install.sh` is safe and recommended when adding drives, upgrading across major versions, or recovering from local edits:
 
-- **Existing `.env` is preserved.** Only `PUID`/`PGID`/`CDROM_GID` are re-derived from the host and overwritten if they drifted.
+- **Existing `.env` is preserved.** Host facts (`CDROM_GID`, `ARM_GPUS`, `ARM_RENDER_GID`) are re-derived and overwritten if they drifted. `PUID`/`PGID` are **not** re-derived: they are operator policy (e.g. a uid hand-tuned to match an NFS export) and any existing non-zero values survive a rerun. Only an unusable `0` value is healed back to the derived uid:gid, and passing explicit `PUID=`/`PGID=` env vars to the rerun overrides the persisted values deliberately.
 - **Existing CA is preserved.** The CA is the one cert LAN clients have imported into their trust stores; regenerating it would force every browser, phone, and laptop to re-import. `install.sh --rotate-ca` is a separate, explicit subcommand that regenerates the CA + all leaves (with a confirmation prompt — the nuclear option for suspected CA key compromise).
 - **All leaf certs are regenerated every run**, signed by the existing CA. Leaves are disposable — LAN clients trust the CA, not the specific leaf, so new leaves are invisible across the network. This self-heals hand-edited / corrupted / stale leaves and picks up SAN changes (e.g. host LAN hostname changed, new drive added) without any special flag or branching in the installer. Running containers keep their in-memory cert until restart; the `docker compose up -d` the user runs next cycles anything whose config changed.
 - **Newly-detected drives** get a new `arm-ripper-srN` service block appended to the compose file and a matching leaf cert.

--- a/docs/arch/06-deployment.md
+++ b/docs/arch/06-deployment.md
@@ -266,7 +266,7 @@ curl -fsSL https://raw.githubusercontent.com/automatic-ripping-machine/automatic
 
 (Or `bash -c "$(curl -fsSL ...)"` for users who want a TTY; `install.sh --prefix /srv/arm` to override the default path.)
 
-**Run it as your regular user, never via `sudo`/root.** Containers drop privileges to the invoking user's uid:gid (`PUID`/`PGID`), and a root run would seed the unusable `0:0` (the entrypoint's `groupadd --gid 0` collides with the root group) plus root-own everything under a `/root/arm` prefix. The installer refuses to run as root; docker access should come from `docker` group membership (`sudo usermod -aG docker $USER && newgrp docker`). Unattended installs on root-only hosts can pass explicit non-root `PUID=`/`PGID=` env vars to bypass the guard.
+**Run it as your regular user, never via `sudo`/root.** Containers drop privileges to the invoking user's uid:gid (`PUID`/`PGID`), and a root run would seed the unusable `0:0` (the entrypoint's `groupadd --gid 0` collides with the root group) plus root-own everything under a `/root/arm` prefix. The installer refuses to run as root; docker access should come from `docker` group membership (`sudo usermod -aG docker $USER && newgrp docker`). Unattended installs on root-only hosts can pass explicit non-root `PUID=`/`PGID=` env vars to bypass the guard — the installer then chowns everything it generated (certs, `.env`, compose, data dirs; `db/` excluded) to that uid:gid so the PUID-dropped containers can actually use it.
 
 **What the installer does, in order:**
 

--- a/install.sh
+++ b/install.sh
@@ -126,10 +126,11 @@ confirm() {
 # ------------------------------------------------ runtime uid/gid resolution
 
 # PUID/PGID are the uid:gid every container drops to via gosu, and the owner
-# the entrypoints expect on the media mounts. 0 is never valid: the shared
-# entrypoint runs `groupadd --gid "${PGID}" arm`, and gid 0 collides with the
-# image's root group — every service crash-loops.
-is_ugid() { [[ "${1:-}" =~ ^[0-9]+$ ]] && (( $1 != 0 )); }
+# the entrypoints expect on the media mounts. 0 is never valid (uid/gid 0 is
+# root in the image; the entrypoint refuses it), leading zeros would be
+# re-parsed as a different id by useradd/groupadd, and anything past the
+# 32-bit id space is rejected by useradd anyway.
+is_ugid() { [[ "${1:-}" =~ ^[1-9][0-9]{0,9}$ ]] && (( $1 <= 4294967294 )); }
 
 # Refuse root runs. Under sudo the whole install is poisoned, not just the
 # uid derivation: HOME=/root moves the default prefix to /root/arm, and every
@@ -138,10 +139,13 @@ is_ugid() { [[ "${1:-}" =~ ^[0-9]+$ ]] && (( $1 != 0 )); }
 # Escape hatch for unattended installs on root-only hosts: pass explicit
 # non-root PUID/PGID env vars (and own the prefix accordingly).
 require_unprivileged() {
-    local euid="${INSTALL_EUID:-$EUID}"   # test seam (devtools/test-install-env.sh)
+    local euid="$EUID"
+    # Test seam — honored ONLY under the source-only test mode, so a stray
+    # ARM_INSTALL_EUID in a real environment can't bypass the root guard.
+    [[ -n "${ARM_INSTALL_SOURCE_ONLY:-}" ]] && euid="${ARM_INSTALL_EUID:-$EUID}"
     (( euid == 0 )) || return 0
     if is_ugid "${PUID:-}" && is_ugid "${PGID:-}"; then
-        warn "running as root with explicit PUID=${PUID} PGID=${PGID}. Files generated under $PREFIX will be root-owned; chown the prefix to ${PUID}:${PGID} if containers fail their writability check."
+        warn "running as root with explicit PUID=${PUID} PGID=${PGID}; generated files under $PREFIX will be chowned to ${PUID}:${PGID} at the end of the run."
         return 0
     fi
     err "do not run install.sh as root/sudo. Containers drop privileges to your uid:gid (PUID/PGID), and a root run seeds the unusable 0:0 — services then crash-loop in the entrypoint's groupadd. Re-run as the regular user that owns the media; if docker requires sudo, join the docker group first: sudo usermod -aG docker \$USER && newgrp docker. (Unattended root installs: pass explicit non-root PUID= and PGID= env vars.)"
@@ -161,6 +165,11 @@ resolve_puid_pgid() {
         return 0
     fi
     ARM_PUID="$(id -u)"; ARM_PGID="$(id -g)"
+    # A non-root user can still carry primary gid 0 (wheel-ish setups on some
+    # NAS/admin accounts) — that seeds a PGID the entrypoint's groupadd rejects.
+    if ! is_ugid "$ARM_PUID" || ! is_ugid "$ARM_PGID"; then
+        err "your uid:gid resolves to ${ARM_PUID}:${ARM_PGID}, which containers cannot run as (uid/gid 0 collides with root in the image). Pass explicit non-root PUID= and PGID= env vars — e.g. the owner of your media directory."
+    fi
 }
 
 # Extract the bare host from a URL: strip scheme://, any user@, :port, and /path.
@@ -273,6 +282,27 @@ ensure_prefix() {
     # 2775 = setgid + group-writable. Per docs/arch/06-deployment.md: lets
     # ARM-created subdirs inherit the parent group automatically.
     chmod 2775 "$PREFIX/raw" "$PREFIX/media" "$PREFIX/logs"
+}
+
+# Root escape-hatch runs (EUID 0 + explicit PUID/PGID) generate root-owned
+# files the gosu-dropped containers can't use: 0400 cert keys become
+# unreadable and the data dirs fail the entrypoint's writability guard.
+# Hand everything this run generated to the target uid:gid. db/ is
+# deliberately excluded — the Postgres image manages its data dir's
+# ownership itself, and chowning a live cluster would break it.
+fix_prefix_ownership() {
+    (( EUID == 0 )) || return 0
+    (( ${ARM_UGID_EXPLICIT:-0} )) || return 0
+    log "root install: chowning generated files under $PREFIX to ${ARM_PUID}:${ARM_PGID} (db/ untouched)"
+    chown "${ARM_PUID}:${ARM_PGID}" "$PREFIX"
+    local p
+    for p in certs raw media logs ssh; do
+        [[ -d "$PREFIX/$p" ]] && chown -R "${ARM_PUID}:${ARM_PGID}" "$PREFIX/$p"
+    done
+    for p in .env docker-compose.yml; do
+        [[ -f "$PREFIX/$p" ]] && chown "${ARM_PUID}:${ARM_PGID}" "$PREFIX/$p"
+    done
+    return 0
 }
 
 # ---------------------------------------------------------- cert generation
@@ -699,16 +729,28 @@ seed_env() {
         # non-zero .env value > this run's derivation (which heals the 0:0 a
         # pre-guard sudo run seeded).
         local cur_puid cur_pgid
-        cur_puid="$(sed -nE 's/^PUID=(.*)$/\1/p' "$env_file" | head -n1)"
-        cur_pgid="$(sed -nE 's/^PGID=(.*)$/\1/p' "$env_file" | head -n1)"
+        # tr strips CR/whitespace so a CRLF-edited .env (Windows editor, WSL)
+        # doesn't read as garbage and get its valid value clobbered.
+        cur_puid="$(sed -nE 's/^PUID=(.*)$/\1/p' "$env_file" | head -n1 | tr -d '[:space:]')"
+        cur_pgid="$(sed -nE 's/^PGID=(.*)$/\1/p' "$env_file" | head -n1 | tr -d '[:space:]')"
         if (( ARM_UGID_EXPLICIT )); then
             if [[ "${cur_puid}:${cur_pgid}" != "${puid}:${pgid}" ]]; then
                 log "explicit override: PUID/PGID ${cur_puid:-unset}:${cur_pgid:-unset} -> ${puid}:${pgid}"
             fi
-        elif is_ugid "$cur_puid" && is_ugid "$cur_pgid"; then
-            puid="$cur_puid"; pgid="$cur_pgid"
-        elif [[ -n "${cur_puid}${cur_pgid}" ]]; then
-            warn "healing unusable PUID/PGID '${cur_puid}:${cur_pgid}' in .env -> ${puid}:${pgid} (0 is never a valid container uid/gid)"
+        else
+            # Preserve each value independently: a half-edited .env (one key
+            # valid, the other missing/0) keeps its good half and heals only
+            # the broken one.
+            if is_ugid "$cur_puid"; then
+                puid="$cur_puid"
+            elif [[ -n "$cur_puid" ]]; then
+                warn "healing unusable PUID '${cur_puid}' in .env -> ${puid} (must be a non-zero numeric uid)"
+            fi
+            if is_ugid "$cur_pgid"; then
+                pgid="$cur_pgid"
+            elif [[ -n "$cur_pgid" ]]; then
+                warn "healing unusable PGID '${cur_pgid}' in .env -> ${pgid} (must be a non-zero numeric gid)"
+            fi
         fi
         log ".env exists; preserving secrets + PUID/PGID ${puid}:${pgid}, re-deriving CDROM_GID/ARM_GPUS/ARM_RENDER_GID"
         sed -i \
@@ -718,6 +760,7 @@ seed_env() {
             "$env_file"
         grep -q '^PUID=' "$env_file" || printf 'PUID=%s\n' "$puid" >> "$env_file"
         grep -q '^PGID=' "$env_file" || printf 'PGID=%s\n' "$pgid" >> "$env_file"
+        grep -q '^CDROM_GID=' "$env_file" || printf 'CDROM_GID=%s\n' "$cdrom_gid" >> "$env_file"
         if grep -q '^ARM_GPUS=' "$env_file"; then
             sed -i "s|^ARM_GPUS=.*|ARM_GPUS=${arm_gpus}|" "$env_file"
         else
@@ -1202,6 +1245,7 @@ main() {
 
     if [[ $CERTS_ONLY -eq 1 ]]; then
         log "certs-only mode; skipping env/compose/udev"
+        fix_prefix_ownership
         return 0
     fi
 
@@ -1216,6 +1260,7 @@ main() {
     [[ $NO_COMPOSE -eq 0 ]] && generate_compose
     [[ $NO_UDEV -eq 0 ]]    && ensure_udev_rule
 
+    fix_prefix_ownership
     print_next_steps
 
     if [[ $START -eq 1 ]]; then

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,11 @@
 # (on desktop hosts) installs a host-side udev rule disabling auto-mount
 # for ARM-managed drives.
 #
+# Run as your regular user, never via sudo/root: containers gosu-drop to the
+# invoking uid:gid (PUID/PGID), and a root run would seed the unusable 0:0
+# and root-own the prefix. The installer refuses to run as root (unattended
+# root installs: pass explicit non-root PUID=/PGID= env vars).
+#
 # Usage:
 #   curl -fsSL .../install.sh | bash
 #   bash install.sh                       # local checkout, default prefix
@@ -118,6 +123,46 @@ confirm() {
     [[ "$reply" =~ ^[yY]([eE][sS])?$ ]]
 }
 
+# ------------------------------------------------ runtime uid/gid resolution
+
+# PUID/PGID are the uid:gid every container drops to via gosu, and the owner
+# the entrypoints expect on the media mounts. 0 is never valid: the shared
+# entrypoint runs `groupadd --gid "${PGID}" arm`, and gid 0 collides with the
+# image's root group — every service crash-loops.
+is_ugid() { [[ "${1:-}" =~ ^[0-9]+$ ]] && (( $1 != 0 )); }
+
+# Refuse root runs. Under sudo the whole install is poisoned, not just the
+# uid derivation: HOME=/root moves the default prefix to /root/arm, and every
+# generated file (certs, .env, compose, media dirs) ends up root-owned, which
+# the PUID-dropped container processes then fail their writability guard on.
+# Escape hatch for unattended installs on root-only hosts: pass explicit
+# non-root PUID/PGID env vars (and own the prefix accordingly).
+require_unprivileged() {
+    local euid="${INSTALL_EUID:-$EUID}"   # test seam (devtools/test-install-env.sh)
+    (( euid == 0 )) || return 0
+    if is_ugid "${PUID:-}" && is_ugid "${PGID:-}"; then
+        warn "running as root with explicit PUID=${PUID} PGID=${PGID}. Files generated under $PREFIX will be root-owned; chown the prefix to ${PUID}:${PGID} if containers fail their writability check."
+        return 0
+    fi
+    err "do not run install.sh as root/sudo. Containers drop privileges to your uid:gid (PUID/PGID), and a root run seeds the unusable 0:0 — services then crash-loop in the entrypoint's groupadd. Re-run as the regular user that owns the media; if docker requires sudo, join the docker group first: sudo usermod -aG docker \$USER && newgrp docker. (Unattended root installs: pass explicit non-root PUID= and PGID= env vars.)"
+}
+
+# Resolve the PUID/PGID this run seeds: explicit env override > invoking user.
+# Sets ARM_PUID/ARM_PGID plus ARM_UGID_EXPLICIT=1 when the operator passed an
+# override — an explicit override is the one thing that outranks values already
+# persisted in .env (see seed_env's preserve-on-rerun rule).
+resolve_puid_pgid() {
+    ARM_UGID_EXPLICIT=0
+    if [[ -n "${PUID:-}" || -n "${PGID:-}" ]]; then
+        if ! is_ugid "${PUID:-}" || ! is_ugid "${PGID:-}"; then
+            err "invalid PUID/PGID override '${PUID:-}:${PGID:-}' — both must be numeric and non-zero."
+        fi
+        ARM_PUID="$PUID"; ARM_PGID="$PGID"; ARM_UGID_EXPLICIT=1
+        return 0
+    fi
+    ARM_PUID="$(id -u)"; ARM_PGID="$(id -g)"
+}
+
 # Extract the bare host from a URL: strip scheme://, any user@, :port, and /path.
 # https://192.168.0.68:8080/api -> 192.168.0.68 ; https://h.example -> h.example
 url_host() {
@@ -170,6 +215,8 @@ resolve_image_tag() {
 
 check_prereqs() {
     log "checking prereqs"
+
+    require_unprivileged
 
     require docker  "install: https://docs.docker.com/engine/install/"
     require openssl "openssl should be present on any modern Linux system"
@@ -549,8 +596,7 @@ setup_remote_offload() {
 
     read -rp "  Remote docker endpoint (ssh://user@host): " REMOTE_DOCKER_HOST
     read -rp "  Routable backend URL the transcoder calls back (https://host:port): " REMOTE_BACKEND_URL
-    local def_puid def_pgid
-    def_puid="$(id -u)"; def_pgid="$(id -g)"
+    local def_puid="$ARM_PUID" def_pgid="$ARM_PGID"
     local uidgid
     read -rp "  Transcoder write UID:GID for shared media [${def_puid}:${def_pgid}]: " uidgid
     uidgid="${uidgid:-${def_puid}:${def_pgid}}"
@@ -592,8 +638,8 @@ setup_remote_offload() {
         printf '  StrictHostKeyChecking accept-new\n'
     } > "$sshdir/config"
     chmod 700 "$sshdir"; chmod 600 "$key" "$sshdir/known_hosts" "$sshdir/config"
-    # Own the ssh bundle as the BACKEND's runtime uid (this installer's own
-    # id -u:id -g, i.e. top-level PUID/PGID — the entrypoint's gosu target),
+    # Own the ssh bundle as the BACKEND's runtime uid (the resolved top-level
+    # PUID/PGID — the entrypoint's gosu target),
     # NOT REMOTE_TRANSCODE_PUID/PGID: that's a different uid by design — the
     # one the *transcoder* drops to for writing the shared media export. The
     # backend is what mounts this dir :ro and reads the 600 key/config, so it
@@ -629,9 +675,7 @@ setup_remote_offload() {
 seed_env() {
     local env_file="$PREFIX/.env"
 
-    local puid pgid cdrom_gid
-    puid="$(id -u)"
-    pgid="$(id -g)"
+    local puid="$ARM_PUID" pgid="$ARM_PGID" cdrom_gid
     cdrom_gid="$(stat -c '%g' /dev/sr0 2>/dev/null || echo 44)"
 
     local arm_gpus render_gid
@@ -649,12 +693,31 @@ seed_env() {
     fi
 
     if [[ -f "$env_file" ]]; then
-        log ".env exists; preserving secrets, re-deriving PUID/PGID/CDROM_GID/ARM_GPUS/ARM_RENDER_GID"
+        # PUID/PGID are operator policy (e.g. NFS uid mappings hand-tuned after
+        # install), not re-derivable host facts — never clobber a usable existing
+        # value on re-run. Precedence: explicit PUID/PGID env override > existing
+        # non-zero .env value > this run's derivation (which heals the 0:0 a
+        # pre-guard sudo run seeded).
+        local cur_puid cur_pgid
+        cur_puid="$(sed -nE 's/^PUID=(.*)$/\1/p' "$env_file" | head -n1)"
+        cur_pgid="$(sed -nE 's/^PGID=(.*)$/\1/p' "$env_file" | head -n1)"
+        if (( ARM_UGID_EXPLICIT )); then
+            if [[ "${cur_puid}:${cur_pgid}" != "${puid}:${pgid}" ]]; then
+                log "explicit override: PUID/PGID ${cur_puid:-unset}:${cur_pgid:-unset} -> ${puid}:${pgid}"
+            fi
+        elif is_ugid "$cur_puid" && is_ugid "$cur_pgid"; then
+            puid="$cur_puid"; pgid="$cur_pgid"
+        elif [[ -n "${cur_puid}${cur_pgid}" ]]; then
+            warn "healing unusable PUID/PGID '${cur_puid}:${cur_pgid}' in .env -> ${puid}:${pgid} (0 is never a valid container uid/gid)"
+        fi
+        log ".env exists; preserving secrets + PUID/PGID, re-deriving CDROM_GID/ARM_GPUS/ARM_RENDER_GID"
         sed -i \
             -e "s|^PUID=.*|PUID=${puid}|" \
             -e "s|^PGID=.*|PGID=${pgid}|" \
             -e "s|^CDROM_GID=.*|CDROM_GID=${cdrom_gid}|" \
             "$env_file"
+        grep -q '^PUID=' "$env_file" || printf 'PUID=%s\n' "$puid" >> "$env_file"
+        grep -q '^PGID=' "$env_file" || printf 'PGID=%s\n' "$pgid" >> "$env_file"
         if grep -q '^ARM_GPUS=' "$env_file"; then
             sed -i "s|^ARM_GPUS=.*|ARM_GPUS=${arm_gpus}|" "$env_file"
         else
@@ -1085,10 +1148,16 @@ to set up nvidia-container-toolkit above.)
 EOF
 }
 
+# Test seam: lets devtools/test-install-env.sh source the functions above
+# without executing the install (mirrors ARM_ENTRYPOINT_SOURCE_ONLY in
+# services/_common/docker-entrypoint.sh). No-op in production.
+[[ -n "${ARM_INSTALL_SOURCE_ONLY:-}" ]] && return 0
+
 # ----------------------------------------------------------------- main
 
 main() {
     check_prereqs
+    resolve_puid_pgid
     ensure_prefix
 
     local REMOTE_OFFLOAD=0 REMOTE_DOCKER_HOST="" REMOTE_BACKEND_URL="" \

--- a/install.sh
+++ b/install.sh
@@ -710,7 +710,7 @@ seed_env() {
         elif [[ -n "${cur_puid}${cur_pgid}" ]]; then
             warn "healing unusable PUID/PGID '${cur_puid}:${cur_pgid}' in .env -> ${puid}:${pgid} (0 is never a valid container uid/gid)"
         fi
-        log ".env exists; preserving secrets + PUID/PGID, re-deriving CDROM_GID/ARM_GPUS/ARM_RENDER_GID"
+        log ".env exists; preserving secrets + PUID/PGID ${puid}:${pgid}, re-deriving CDROM_GID/ARM_GPUS/ARM_RENDER_GID"
         sed -i \
             -e "s|^PUID=.*|PUID=${puid}|" \
             -e "s|^PGID=.*|PGID=${pgid}|" \
@@ -758,7 +758,7 @@ seed_env() {
         return 0
     fi
 
-    log "generating .env with random secrets"
+    log "generating .env with random secrets (containers run as PUID:PGID ${puid}:${pgid})"
     local pg_pass arm_tok
     pg_pass="$(openssl rand -hex 24)"
     arm_tok="$(openssl rand -hex 32)"

--- a/services/_common/docker-entrypoint.sh
+++ b/services/_common/docker-entrypoint.sh
@@ -71,10 +71,18 @@ if [[ -f /etc/ssl/arm/arm-ca.crt ]]; then
     update-ca-certificates >/dev/null
 fi
 
-if ! getent group arm >/dev/null; then
-    groupadd --gid "${PGID}" arm
-else
-    groupmod --gid "${PGID}" arm
+# Give the arm user primary gid PGID. If that gid ALREADY exists in the image
+# (gid 100 `users` — a common primary gid on SUSE/Synology hosts — or any
+# Debian system gid), adopt the existing group instead: groupadd/groupmod
+# refuse a duplicate gid and the service would crash-loop. useradd/usermod
+# below take the numeric gid directly, whatever group name owns it. Mirrors
+# the CDROM_GID/RENDER_GID adopt-by-gid handling further down.
+if ! getent group "${PGID}" >/dev/null; then
+    if getent group arm >/dev/null; then
+        groupmod --gid "${PGID}" arm
+    else
+        groupadd --gid "${PGID}" arm
+    fi
 fi
 
 if ! id -u arm >/dev/null 2>&1; then

--- a/services/ripper/arm_ripper/job_controller.py
+++ b/services/ripper/arm_ripper/job_controller.py
@@ -11,6 +11,7 @@ from arm_common import DiscType, Job, JobStatus, TrackStatus, with_log_context
 from arm_common.schemas import JobView, RipperConfigView, RipStartResponse, ScanResult, TrackView, WSEnvelope
 from arm_ripper.backend_client import BackendClient
 from arm_ripper.community_keydb import refresh_community_keydb
+from arm_ripper.drive_poll import DriveState, read_drive_status
 from arm_ripper.makemkv_key import refresh_makemkv_key
 from arm_ripper.rip import RipResult, rip_all
 from arm_ripper.rip.dispatcher import DEFAULT_MIN_LENGTH_SECONDS
@@ -121,6 +122,10 @@ class JobController:
         # the raw dir for cleanup. Set inside `_run_pipeline` only.
         self._active_task: asyncio.Task[None] | None = None
         self._active_job_id: str | None = None
+        # Abandon-triggered eject runs fire-and-forget (the WS handler is
+        # sync); kept here so overlapping abandon signals don't stack
+        # umount/eject subprocess retries. Set inside `_spawn_eject` only.
+        self._eject_task: asyncio.Task[None] | None = None
 
     @property
     def is_active(self) -> bool:
@@ -200,17 +205,20 @@ class JobController:
             logger.debug("ws command ignored: type=%s", envelope.event_type)
 
     def _handle_abandon(self, job_id: str, *, delete_raw: bool) -> None:
-        """Cancel the active pipeline if it owns this job, then optionally
-        wipe `/raw/<job_id>/`. Runs synchronously from the WS handler;
-        cancel + rmtree are both fast and don't need awaitable plumbing.
+        """Cancel the active pipeline if it owns this job, optionally wipe
+        `/raw/<job_id>/`, then give the disc back. Runs synchronously from
+        the WS handler; cancel + rmtree are both fast and don't need
+        awaitable plumbing (eject spawns as a task).
 
         rmtree on Linux is safe even if makemkvcon still has file handles
         open: the directory entries are removed, existing fds keep working
         (writing to nowhere) until the cancelled subprocess dies.
         """
-        if self._active_job_id == job_id and self._active_task is not None and not self._active_task.done():
+        active = self._active_task
+        owns = self._active_job_id == job_id and active is not None and not active.done()
+        if active is not None and owns:
             logger.info("job.abandoned: cancelling active task for job_id=%s", job_id)
-            self._active_task.cancel()
+            active.cancel()
         if delete_raw:
             target = RAW_ROOT / job_id
             try:
@@ -220,6 +228,37 @@ class JobController:
                 logger.info("raw dir already absent job_id=%s path=%s", job_id, target)
             except OSError as exc:
                 logger.warning("raw-dir cleanup failed job_id=%s path=%s: %s", job_id, target, exc)
+        # Abandon means "done with this disc — give it back". The lifecycle's
+        # post-rip eject (end of _run_rip) never runs on an abandon exit, so
+        # eject here: when this job owns the drive's pipeline (ripping or
+        # parked — _eject_with_retry's EBUSY retries absorb the cancelled
+        # makemkvcon's teardown), or when the drive is idle with a disc still
+        # seated (pipeline already exited, e.g. after a rip-start abort). A
+        # stale abandon while a DIFFERENT job's rip owns the drive must not
+        # pop the tray mid-rip.
+        idle = active is None or active.done()
+        if owns or (idle and self._disc_seated()):
+            self._spawn_eject()
+
+    def _disc_seated(self) -> bool:
+        """True when the drive currently reports a seated disc (DISC_OK) —
+        guards abandon-eject so abandoning an old job from history with an
+        empty (or already-ejected) drive doesn't pop the tray."""
+        if self._device_path is None or is_iso_source(self._device_path):
+            return False
+        try:
+            return read_drive_status(self._device_path) == DriveState.DISC_OK
+        except OSError:
+            return False
+
+    def _spawn_eject(self) -> None:
+        """Fire-and-forget eject for the sync abandon handler; deduped so
+        overlapping abandon signals don't stack umount/eject retries."""
+        if self._device_path is None:
+            return
+        if self._eject_task is not None and not self._eject_task.done():
+            return
+        self._eject_task = asyncio.create_task(self._eject_with_retry(self._device_path))
 
     async def handle_manual_trigger(self, session_id: str | None) -> None:
         """Run the normal scan→identify→rip flow on demand, threading

--- a/services/ripper/tests/test_job_controller.py
+++ b/services/ripper/tests/test_job_controller.py
@@ -246,6 +246,117 @@ async def test_review_gate_cancel_abandons_without_rip(stub_scan, stub_eject):
     assert client.rip_complete_calls == []
 
 
+# --- abandon gives the disc back (user report: abandon left the disc seated) ----
+
+
+@pytest.fixture
+def eject_spy(monkeypatch):
+    calls: list[str] = []
+
+    async def _spy(self, device_path: str) -> None:
+        calls.append(device_path)
+
+    monkeypatch.setattr(jc_module.JobController, "_eject_with_retry", _spy)
+    return calls
+
+
+def _abandon_envelope() -> WSEnvelope:
+    return WSEnvelope(
+        event_id="evt_abandon",
+        event_type="job.abandoned",
+        emitted_at=datetime.now(timezone.utc),
+        topic="ripper.commands.drv_test",
+        job_id="job_test",
+        payload={"job_id": "job_test", "delete_raw": False},
+    )
+
+
+async def test_abandon_while_parked_cancels_and_ejects(stub_scan, eject_spy, monkeypatch):
+    """Abandoning a job parked in AWAITING_USER_ID cancels the parked pipeline
+    AND pops the tray — the post-rip eject never runs on an abandon exit."""
+    monkeypatch.setattr(jc_module, "RESOLUTION_WS_FIRST_WAIT_SECONDS", 5.0)
+    monkeypatch.setattr(jc_module, "RESOLUTION_WAIT_TIMEOUT_SECONDS", 30.0)
+    client = FakeClient()
+    client.identify_responses.append(_job(JobStatus.AWAITING_USER_ID))
+    controller = JobController(client, "drv_test", device_path="/dev/sr0")
+
+    pipeline = asyncio.create_task(controller.handle_disc_inserted("/dev/sr0"))
+    await asyncio.sleep(0.05)  # reach _wait_for_resolution
+    await controller.on_ws_command(_abandon_envelope())
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(pipeline, timeout=2.0)
+    await asyncio.sleep(0.01)  # let the spawned eject task run
+
+    assert eject_spy == ["/dev/sr0"]
+    assert client.rip_start_calls == []
+
+
+async def test_abandon_during_rip_cancels_and_ejects(stub_scan, eject_spy):
+    """Abandon mid-rip cancels the pipeline task and still ejects the disc."""
+    client = FakeClient()
+    client.identify_responses.append(_job(JobStatus.IDENTIFIED, title="Mid Rip"))
+    rip_started = asyncio.Event()
+
+    async def _hanging_rip_start(job_id: str) -> RipStartResponse:
+        client.rip_start_calls.append(job_id)
+        rip_started.set()
+        await asyncio.sleep(3600)
+        raise AssertionError("unreachable")
+
+    client.rip_start = _hanging_rip_start  # type: ignore[method-assign]
+    controller = JobController(client, "drv_test", device_path="/dev/sr0")
+
+    pipeline = asyncio.create_task(controller.handle_disc_inserted("/dev/sr0"))
+    await asyncio.wait_for(rip_started.wait(), timeout=2.0)
+    await controller.on_ws_command(_abandon_envelope())
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(pipeline, timeout=2.0)
+    await asyncio.sleep(0.01)
+
+    assert eject_spy == ["/dev/sr0"]
+    assert client.rip_complete_calls == []
+
+
+async def test_abandon_idle_drive_with_disc_seated_ejects(eject_spy, monkeypatch):
+    """Abandon after the pipeline already exited (e.g. rip-start abort): the
+    idle drive still holds the disc — give it back."""
+    monkeypatch.setattr(jc_module, "read_drive_status", lambda _d: jc_module.DriveState.DISC_OK)
+    controller = JobController(FakeClient(), "drv_test", device_path="/dev/sr0")
+
+    controller._handle_abandon("job_test", delete_raw=False)
+    await asyncio.sleep(0.01)
+
+    assert eject_spy == ["/dev/sr0"]
+
+
+async def test_abandon_idle_drive_without_disc_does_not_eject(eject_spy, monkeypatch):
+    """Abandoning an old job from history with an empty drive must not pop
+    the tray."""
+    monkeypatch.setattr(jc_module, "read_drive_status", lambda _d: jc_module.DriveState.NO_DISC)
+    controller = JobController(FakeClient(), "drv_test", device_path="/dev/sr0")
+
+    controller._handle_abandon("job_test", delete_raw=False)
+    await asyncio.sleep(0.01)
+
+    assert eject_spy == []
+
+
+async def test_abandon_stale_job_during_other_rip_does_not_eject(eject_spy):
+    """A stale abandon while a DIFFERENT job's rip owns the drive must not
+    cancel it or eject its disc mid-rip."""
+    controller = JobController(FakeClient(), "drv_test", device_path="/dev/sr0")
+    other = asyncio.create_task(asyncio.sleep(3600))
+    controller._active_task = other
+    controller._active_job_id = "job_other"
+
+    controller._handle_abandon("job_test", delete_raw=False)
+    await asyncio.sleep(0.01)
+
+    assert eject_spy == []
+    assert not other.cancelled()
+    other.cancel()
+
+
 async def test_review_gate_auto_starts_when_countdown_elapsed(stub_scan, stub_eject):
     """With the countdown elapsed (wait_start_time in the past, short
     manual_wait_seconds) and not paused, the parked ripper auto-starts the rip


### PR DESCRIPTION
Four fixes driven by deploy-test-group feedback, split out of #41 (they were briefly stacked there; #41 is now restored to pure remote-offload scope).

## Merge order (important)

**Aligns to Tier-26; merge AFTER #41, never before.** This PR's base is #41's branch — merging it while that base is still open would fold these commits back into #41's diff. Once #41 merges (and its branch is deleted), GitHub auto-retargets this PR down the stack; when it eventually points at `main`, the diff reduces to just these four commits. It has no dependency on the Tier-27+ chain (#42–#47), so it can land immediately after #41, in parallel with those.

## Commits

1. **`f97b8fb5` installer: refuse root runs; preserve operator PUID/PGID on rerun** — a sudo run seeded `PUID/PGID=0:0` (containers crash-loop in the entrypoint's `groupadd --gid 0`), and re-runs sed-clobbered hand-fixed values while logging "preserving your .env". Root is now refused with an actionable message (explicit non-root `PUID=`/`PGID=` env vars as the unattended escape hatch), reruns preserve existing non-zero values and heal only broken ones, and a new plain-bash suite covers it (sourced via an `ARM_INSTALL_SOURCE_ONLY` seam, mirroring the entrypoint guard test).
2. **`4a21bb6a` installer: log the effective PUID:PGID** on both fresh seed and rerun, so a mismatch is visible in install output instead of surfacing as a container crash-loop.
3. **`69257015` review-pass hardening** — derived-gid-0 validation (non-root users with primary gid 0), per-field heal (half-edited .env keeps its valid half), root-escape-hatch installs chown what they generated, CRLF-safe `.env` reads (Windows-edited files), entrypoint adopts an already-existing PGID group (e.g. gid 100 `users` on SUSE/Synology-style hosts) instead of crash-looping, and a CI `test-shell` job that actually runs both bash suites.
4. **`802719f0` ripper: eject the disc when a job is abandoned** — eject previously ran only at the successful-rip tail, so abandoning (mid-rip, parked awaiting-user-id/review, or after an aborted pipeline) left the disc seated. The `job.abandoned` handler now spawns a deduped eject when the abandoned job owns the drive's pipeline or the idle drive still seats the disc; a stale abandon during a different job's rip never touches the tray. Six new fake-client tests.

All verified: 29-check installer suite + entrypoint-gid simulation, full pytest suite green, live-deployed on the hifi test box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)