### PR TITLE
feat: Tier-2.1 - metadata search/lookup (OMDb, TMDB, MusicBrainz)

### DIFF
--- a/packages/arm_common/arm_common/schemas/__init__.py
+++ b/packages/arm_common/arm_common/schemas/__init__.py
@@ -34,6 +34,8 @@ from arm_common.schemas.metadata import (
     MetadataCandidate,
     MetadataKeyTestResponse,
     MetadataProvider,
+    MetadataReleaseDetail,
+    MetadataReleaseTrack,
     MetadataSearchResponse,
 )
 from arm_common.schemas.naming import (
@@ -98,6 +100,8 @@ __all__ = [
     "MetadataCandidate",
     "MetadataKeyTestResponse",
     "MetadataProvider",
+    "MetadataReleaseDetail",
+    "MetadataReleaseTrack",
     "MetadataSearchResponse",
     "ApplySessionRequest",
     "BulkDeleteJobsResponse",

--- a/packages/arm_common/arm_common/schemas/__init__.py
+++ b/packages/arm_common/arm_common/schemas/__init__.py
@@ -30,7 +30,12 @@ from arm_common.schemas.jobs import (
     RipStartResponse,
     TrackView,
 )
-from arm_common.schemas.metadata import MetadataKeyTestResponse, MetadataProvider
+from arm_common.schemas.metadata import (
+    MetadataCandidate,
+    MetadataKeyTestResponse,
+    MetadataProvider,
+    MetadataSearchResponse,
+)
 from arm_common.schemas.naming import (
     JobNamingPreviewResponse,
     NamingPreviewItem,
@@ -90,8 +95,10 @@ from arm_common.schemas.ws import (
 
 __all__ = [
     "AbandonJobRequest",
+    "MetadataCandidate",
     "MetadataKeyTestResponse",
     "MetadataProvider",
+    "MetadataSearchResponse",
     "ApplySessionRequest",
     "BulkDeleteJobsResponse",
     "DiscFingerprintInput",

--- a/packages/arm_common/arm_common/schemas/metadata.py
+++ b/packages/arm_common/arm_common/schemas/metadata.py
@@ -9,3 +9,16 @@ class MetadataKeyTestResponse(BaseModel):
     provider: MetadataProvider
     valid: bool
     detail: str | None = None
+
+
+class MetadataCandidate(BaseModel):
+    title: str
+    year: int | None = None
+    kind: str
+    poster_url: str | None = None
+    provider_id: str | None = None
+
+
+class MetadataSearchResponse(BaseModel):
+    candidates: list[MetadataCandidate]
+    detail: str | None = None

--- a/packages/arm_common/arm_common/schemas/metadata.py
+++ b/packages/arm_common/arm_common/schemas/metadata.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 MetadataProvider = Literal["omdb", "tmdb", "tvdb", "makemkv"]
 
@@ -17,6 +17,20 @@ class MetadataCandidate(BaseModel):
     kind: str
     poster_url: str | None = None
     provider_id: str | None = None
+
+
+class MetadataReleaseTrack(BaseModel):
+    position: int | None = None
+    title: str
+
+
+class MetadataReleaseDetail(BaseModel):
+    release_id: str
+    title: str
+    artist: str | None = None
+    year: int | None = None
+    poster_url: str | None = None
+    tracks: list[MetadataReleaseTrack] = Field(default_factory=list)
 
 
 class MetadataSearchResponse(BaseModel):

--- a/services/backend/arm_backend/metadata/musicbrainz.py
+++ b/services/backend/arm_backend/metadata/musicbrainz.py
@@ -38,13 +38,19 @@ class MusicBrainzClient:
         self._user_agent = user_agent
         self._http = http
 
-    async def lookup_disc_id(self, disc_id: str) -> MetadataResult:
+    async def _get(self, path: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Rate-limit, execute GET, handle transport errors and bad statuses.
+
+        Enforces the 1 req/s rate limit, sets the required User-Agent header,
+        and converts transport failures and non-200 HTTP statuses into the
+        appropriate LookupError / LookupTimeout. Returns the parsed JSON body.
+        """
         await _rate_limit()
 
         try:
             r = await self._http.get(
-                f"{_BASE_URL}/discid/{disc_id}",
-                params={"inc": "artists+recordings", "fmt": "json"},
+                f"{_BASE_URL}{path}",
+                params=params,
                 headers={"User-Agent": self._user_agent, "Accept": "application/json"},
             )
         except httpx.TimeoutException as e:
@@ -52,14 +58,19 @@ class MusicBrainzClient:
         except httpx.HTTPError as e:
             raise LookupError(f"musicbrainz transport error: {e}") from e
 
-        if r.status_code == 404:
-            raise LookupError("musicbrainz disc_id not found")
         if r.status_code >= 500:
             raise LookupError(f"musicbrainz 5xx status={r.status_code}")
         if r.status_code != 200:
             raise LookupError(f"musicbrainz status={r.status_code}")
 
-        body: dict[str, Any] = r.json()
+        return r.json()  # type: ignore[no-any-return]
+
+    async def lookup_disc_id(self, disc_id: str) -> MetadataResult:
+        body = await self._get(
+            f"/discid/{disc_id}",
+            params={"inc": "artists+recordings", "fmt": "json"},
+        )
+
         releases = body.get("releases") or []
         if not releases:
             raise LookupError("musicbrainz disc_id has no releases")
@@ -87,6 +98,26 @@ class MusicBrainzClient:
         }
 
         return MetadataResult(title=title_val, year=year_val, kind="music", payload=payload)
+
+    async def search_releases(self, query: str, limit: int = 10) -> list[MetadataResult]:
+        """Lucene release search for interactive lookup. Returns up to `limit`."""
+        body = await self._get(
+            "/release",
+            params={"query": query, "fmt": "json", "limit": limit},
+        )
+
+        results: list[MetadataResult] = []
+        for rel in (body.get("releases") or [])[:limit]:
+            title = rel.get("title")
+            if not title:
+                continue
+            date = rel.get("date") or ""
+            year: int | None = int(date[:4]) if date[:4].isdigit() else None
+            artist = _join_artist_credit(rel.get("artist-credit") or [])
+            payload: dict[str, Any] = {"artist": artist, "album": title, **rel}
+            results.append(MetadataResult(title=title, year=year, kind="music", payload=payload))
+
+        return results
 
 
 def _join_artist_credit(credit: list[dict[str, Any]]) -> str:

--- a/services/backend/arm_backend/metadata/musicbrainz.py
+++ b/services/backend/arm_backend/metadata/musicbrainz.py
@@ -104,6 +104,33 @@ class MusicBrainzClient:
 
         return MetadataResult(title=title_val, year=year_val, kind="music", payload=payload)
 
+    async def get_release(self, release_id: str) -> MetadataResult:
+        """Fetch a single MusicBrainz release by MBID for interactive detail.
+
+        Mirrors lookup_disc_id's projection (artist/album/tracks spread over the
+        raw release dict) but keyed on a known release MBID instead of a disc-id
+        lookup. A 404 (unknown MBID) surfaces as the not-found LookupError.
+        """
+        body = await self._get(
+            f"/release/{release_id}",
+            params={"inc": "artists+recordings+labels", "fmt": "json"},
+            not_found_detail="musicbrainz release not found",
+        )
+        title_val = body.get("title")
+        if not title_val:
+            raise LookupError("musicbrainz release missing title")
+        year_val = _parse_year(body.get("date") or "")
+        artist = _join_artist_credit(body.get("artist-credit") or [])
+        media = body.get("media") or []
+        tracks = _extract_tracks(media[0] if media else None)
+        payload: dict[str, Any] = {
+            "artist": artist,
+            "album": title_val,
+            "tracks": tracks,
+            **body,
+        }
+        return MetadataResult(title=title_val, year=year_val, kind="music", payload=payload)
+
     async def search_releases(self, query: str, limit: int = 10) -> list[MetadataResult]:
         """Lucene release search for interactive lookup. Returns up to `limit`."""
         body = await self._get(

--- a/services/backend/arm_backend/metadata/musicbrainz.py
+++ b/services/backend/arm_backend/metadata/musicbrainz.py
@@ -38,12 +38,15 @@ class MusicBrainzClient:
         self._user_agent = user_agent
         self._http = http
 
-    async def _get(self, path: str, params: dict[str, Any]) -> dict[str, Any]:
+    async def _get(self, path: str, params: dict[str, Any], *, not_found_detail: str | None = None) -> dict[str, Any]:
         """Rate-limit, execute GET, handle transport errors and bad statuses.
 
         Enforces the 1 req/s rate limit, sets the required User-Agent header,
         and converts transport failures and non-200 HTTP statuses into the
         appropriate LookupError / LookupTimeout. Returns the parsed JSON body.
+
+        `not_found_detail`, when set, gives a 404 a caller-specific message
+        (e.g. "disc_id not found" — an expected miss, not a generic HTTP error).
         """
         await _rate_limit()
 
@@ -58,6 +61,8 @@ class MusicBrainzClient:
         except httpx.HTTPError as e:
             raise LookupError(f"musicbrainz transport error: {e}") from e
 
+        if not_found_detail is not None and r.status_code == 404:
+            raise LookupError(not_found_detail)
         if r.status_code >= 500:
             raise LookupError(f"musicbrainz 5xx status={r.status_code}")
         if r.status_code != 200:
@@ -69,6 +74,7 @@ class MusicBrainzClient:
         body = await self._get(
             f"/discid/{disc_id}",
             params={"inc": "artists+recordings", "fmt": "json"},
+            not_found_detail="musicbrainz disc_id not found",
         )
 
         releases = body.get("releases") or []

--- a/services/backend/arm_backend/metadata/musicbrainz.py
+++ b/services/backend/arm_backend/metadata/musicbrainz.py
@@ -83,8 +83,7 @@ class MusicBrainzClient:
 
         top = releases[0]
         title_val = top.get("title")
-        date = top.get("date") or ""
-        year_val = int(date[:4]) if date[:4].isdigit() else None
+        year_val = _parse_year(top.get("date") or "")
         if not title_val:
             raise LookupError("musicbrainz top release missing title")
 
@@ -113,17 +112,22 @@ class MusicBrainzClient:
         )
 
         results: list[MetadataResult] = []
+        # MB's `limit` query param is advisory; re-cap client-side as a guard.
         for rel in (body.get("releases") or [])[:limit]:
             title = rel.get("title")
             if not title:
                 continue
-            date = rel.get("date") or ""
-            year: int | None = int(date[:4]) if date[:4].isdigit() else None
+            year = _parse_year(rel.get("date") or "")
             artist = _join_artist_credit(rel.get("artist-credit") or [])
             payload: dict[str, Any] = {"artist": artist, "album": title, **rel}
             results.append(MetadataResult(title=title, year=year, kind="music", payload=payload))
 
         return results
+
+
+def _parse_year(date: str) -> int | None:
+    """Year from a MusicBrainz date string ("1973-03-01" -> 1973), or None."""
+    return int(date[:4]) if date[:4].isdigit() else None
 
 
 def _join_artist_credit(credit: list[dict[str, Any]]) -> str:

--- a/services/backend/arm_backend/metadata/omdb.py
+++ b/services/backend/arm_backend/metadata/omdb.py
@@ -58,3 +58,68 @@ class OMDBClient:
             raise LookupError("omdb hit missing title")
 
         return MetadataResult(title=title_val, year=year_val, kind=kind, payload=body)
+
+    async def search_candidates(
+        self,
+        title: str,
+        kind: Literal["movie", "tv"] = "movie",
+        limit: int = 10,
+    ) -> list[MetadataResult]:
+        """Return up to `limit` candidates for an interactive search (OMDB `s=`)."""
+        params: dict[str, Any] = {"apikey": self._api_key, "s": title, "type": kind}
+        try:
+            r = await self._http.get(_BASE_URL, params=params)
+        except httpx.TimeoutException as e:
+            raise LookupTimeout("omdb timeout") from e
+        except httpx.HTTPError as e:
+            raise LookupError(f"omdb transport error: {e}") from e
+
+        if r.status_code == 401:
+            logger.warning("omdb auth_failed status=401")
+            raise LookupError("omdb auth failed")
+        if r.status_code >= 500:
+            raise LookupError(f"omdb 5xx status={r.status_code}")
+        if r.status_code != 200:
+            raise LookupError(f"omdb status={r.status_code}")
+
+        body = r.json()
+        if body.get("Response") != "True":
+            return []  # "Movie not found!" etc. — a real empty result, not an error
+        out: list[MetadataResult] = []
+        for item in (body.get("Search") or [])[:limit]:
+            title_val = item.get("Title")
+            if not title_val:
+                continue
+            year_str = item.get("Year") or ""
+            year_val = int(year_str[:4]) if year_str[:4].isdigit() else None
+            out.append(MetadataResult(title=title_val, year=year_val, kind=kind, payload=item))
+        return out
+
+    async def lookup_by_imdb_id(self, imdb_id: str) -> MetadataResult:
+        """Full details for a known IMDb id (OMDB `i=`)."""
+        params: dict[str, Any] = {"apikey": self._api_key, "i": imdb_id}
+        try:
+            r = await self._http.get(_BASE_URL, params=params)
+        except httpx.TimeoutException as e:
+            raise LookupTimeout("omdb timeout") from e
+        except httpx.HTTPError as e:
+            raise LookupError(f"omdb transport error: {e}") from e
+
+        if r.status_code == 401:
+            logger.warning("omdb auth_failed status=401")
+            raise LookupError("omdb auth failed")
+        if r.status_code >= 500:
+            raise LookupError(f"omdb 5xx status={r.status_code}")
+        if r.status_code != 200:
+            raise LookupError(f"omdb status={r.status_code}")
+
+        body = r.json()
+        if body.get("Response") != "True":
+            raise LookupError(f"omdb miss: {body.get('Error', 'unknown')}")
+        title_val = body.get("Title")
+        if not title_val:
+            raise LookupError("omdb hit missing title")
+        year_str = body.get("Year") or ""
+        year_val = int(year_str[:4]) if year_str[:4].isdigit() else None
+        kind: Literal["movie", "tv"] = "tv" if body.get("Type") == "series" else "movie"
+        return MetadataResult(title=title_val, year=year_val, kind=kind, payload=body)

--- a/services/backend/arm_backend/metadata/omdb.py
+++ b/services/backend/arm_backend/metadata/omdb.py
@@ -76,7 +76,11 @@ class OMDBClient:
         kind: Literal["movie", "tv"] = "movie",
         limit: int = 10,
     ) -> list[MetadataResult]:
-        """Return up to `limit` candidates for an interactive search (OMDB `s=`)."""
+        """Return up to `limit` candidates for an interactive search (OMDB `s=`).
+
+        OMDB's `s=` returns at most 10 results per page; `limit` is applied
+        client-side on top of that, so the effective cap is min(limit, 10).
+        """
         body = await self._get_json({"s": title, "type": kind})
         if body.get("Response") != "True":
             return []  # "Movie not found!" etc. — a real empty result, not an error

--- a/services/backend/arm_backend/metadata/omdb.py
+++ b/services/backend/arm_backend/metadata/omdb.py
@@ -22,18 +22,16 @@ class OMDBClient:
         self._api_key = api_key
         self._http = http
 
-    async def lookup_by_title(
-        self,
-        title: str,
-        year: int | None = None,
-        kind: Literal["movie", "tv"] = "movie",
-    ) -> MetadataResult:
-        params: dict[str, Any] = {"apikey": self._api_key, "t": title, "type": kind}
-        if year is not None:
-            params["y"] = year
+    async def _get_json(self, params: dict[str, Any]) -> dict[str, Any]:
+        """GET the OMDB endpoint and return the parsed JSON body.
 
+        Centralizes the transport + HTTP-status handling shared by every OMDB
+        call: TimeoutException -> LookupTimeout, other transport errors and
+        401/5xx/non-200 -> LookupError. `apikey` is injected here so callers
+        only pass the query-specific params.
+        """
         try:
-            r = await self._http.get(_BASE_URL, params=params)
+            r = await self._http.get(_BASE_URL, params={"apikey": self._api_key, **params})
         except httpx.TimeoutException as e:
             raise LookupTimeout("omdb timeout") from e
         except httpx.HTTPError as e:
@@ -47,7 +45,20 @@ class OMDBClient:
         if r.status_code != 200:
             raise LookupError(f"omdb status={r.status_code}")
 
-        body = r.json()
+        body: dict[str, Any] = r.json()
+        return body
+
+    async def lookup_by_title(
+        self,
+        title: str,
+        year: int | None = None,
+        kind: Literal["movie", "tv"] = "movie",
+    ) -> MetadataResult:
+        params: dict[str, Any] = {"t": title, "type": kind}
+        if year is not None:
+            params["y"] = year
+
+        body = await self._get_json(params)
         if body.get("Response") != "True":
             raise LookupError(f"omdb miss: {body.get('Error', 'unknown')}")
 
@@ -66,23 +77,7 @@ class OMDBClient:
         limit: int = 10,
     ) -> list[MetadataResult]:
         """Return up to `limit` candidates for an interactive search (OMDB `s=`)."""
-        params: dict[str, Any] = {"apikey": self._api_key, "s": title, "type": kind}
-        try:
-            r = await self._http.get(_BASE_URL, params=params)
-        except httpx.TimeoutException as e:
-            raise LookupTimeout("omdb timeout") from e
-        except httpx.HTTPError as e:
-            raise LookupError(f"omdb transport error: {e}") from e
-
-        if r.status_code == 401:
-            logger.warning("omdb auth_failed status=401")
-            raise LookupError("omdb auth failed")
-        if r.status_code >= 500:
-            raise LookupError(f"omdb 5xx status={r.status_code}")
-        if r.status_code != 200:
-            raise LookupError(f"omdb status={r.status_code}")
-
-        body = r.json()
+        body = await self._get_json({"s": title, "type": kind})
         if body.get("Response") != "True":
             return []  # "Movie not found!" etc. — a real empty result, not an error
         out: list[MetadataResult] = []
@@ -97,23 +92,7 @@ class OMDBClient:
 
     async def lookup_by_imdb_id(self, imdb_id: str) -> MetadataResult:
         """Full details for a known IMDb id (OMDB `i=`)."""
-        params: dict[str, Any] = {"apikey": self._api_key, "i": imdb_id}
-        try:
-            r = await self._http.get(_BASE_URL, params=params)
-        except httpx.TimeoutException as e:
-            raise LookupTimeout("omdb timeout") from e
-        except httpx.HTTPError as e:
-            raise LookupError(f"omdb transport error: {e}") from e
-
-        if r.status_code == 401:
-            logger.warning("omdb auth_failed status=401")
-            raise LookupError("omdb auth failed")
-        if r.status_code >= 500:
-            raise LookupError(f"omdb 5xx status={r.status_code}")
-        if r.status_code != 200:
-            raise LookupError(f"omdb status={r.status_code}")
-
-        body = r.json()
+        body = await self._get_json({"i": imdb_id})
         if body.get("Response") != "True":
             raise LookupError(f"omdb miss: {body.get('Error', 'unknown')}")
         title_val = body.get("Title")

--- a/services/backend/arm_backend/metadata/tmdb.py
+++ b/services/backend/arm_backend/metadata/tmdb.py
@@ -51,10 +51,10 @@ class TMDBClient:
         return results
 
     @staticmethod
-    def _parse_one(top: dict[str, Any], endpoint: str, kind: Literal["movie", "tv"]) -> MetadataResult | None:
+    def _parse_one(top: dict[str, Any], kind: Literal["movie", "tv"]) -> MetadataResult | None:
         """Map one TMDB result dict to a MetadataResult, or None if it has no
         usable title. Movie/TV differ only in the title/date field names."""
-        if endpoint == "movie":
+        if kind == "movie":
             release = top.get("release_date") or ""
             title_val = top.get("title") or top.get("original_title") or ""
         else:
@@ -96,7 +96,7 @@ class TMDBClient:
         results = await self._get_results(endpoint, params)
         out: list[MetadataResult] = []
         for top in results[:limit]:
-            parsed = self._parse_one(top, endpoint, kind)
+            parsed = self._parse_one(top, kind)
             if parsed is not None:
                 out.append(parsed)
         return out
@@ -111,7 +111,7 @@ class TMDBClient:
         results = await self._get_results(endpoint, params)
         if not results:
             raise LookupError(f"tmdb {endpoint} no results")
-        parsed = self._parse_one(results[0], endpoint, kind)
+        parsed = self._parse_one(results[0], kind)
         if parsed is None:
             raise LookupError(f"tmdb {endpoint} top result missing title")
         return parsed

--- a/services/backend/arm_backend/metadata/tmdb.py
+++ b/services/backend/arm_backend/metadata/tmdb.py
@@ -25,6 +25,46 @@ class TMDBClient:
     def _headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self._api_key}", "Accept": "application/json"}
 
+    async def _get_results(self, endpoint: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+        """GET /search/{endpoint} and return the raw `results` list.
+
+        Centralizes the transport + HTTP-status handling shared by the top-hit
+        and multi-candidate search paths: TimeoutException -> LookupTimeout,
+        other transport errors and 401/5xx/non-200 -> LookupError.
+        """
+        try:
+            r = await self._http.get(f"{_BASE_URL}/search/{endpoint}", params=params, headers=self._headers)
+        except httpx.TimeoutException as e:
+            raise LookupTimeout(f"tmdb {endpoint} timeout") from e
+        except httpx.HTTPError as e:
+            raise LookupError(f"tmdb {endpoint} transport error: {e}") from e
+
+        if r.status_code == 401:
+            logger.warning("tmdb auth_failed status=401")
+            raise LookupError("tmdb auth failed")
+        if r.status_code >= 500:
+            raise LookupError(f"tmdb {endpoint} 5xx status={r.status_code}")
+        if r.status_code != 200:
+            raise LookupError(f"tmdb {endpoint} status={r.status_code}")
+
+        results: list[dict[str, Any]] = r.json().get("results") or []
+        return results
+
+    @staticmethod
+    def _parse_one(top: dict[str, Any], endpoint: str, kind: Literal["movie", "tv"]) -> MetadataResult | None:
+        """Map one TMDB result dict to a MetadataResult, or None if it has no
+        usable title. Movie/TV differ only in the title/date field names."""
+        if endpoint == "movie":
+            release = top.get("release_date") or ""
+            title_val = top.get("title") or top.get("original_title") or ""
+        else:
+            release = top.get("first_air_date") or ""
+            title_val = top.get("name") or top.get("original_name") or ""
+        if not title_val:
+            return None
+        year_val = int(release[:4]) if release[:4].isdigit() else None
+        return MetadataResult(title=title_val, year=year_val, kind=kind, payload=top)
+
     async def search_movie(self, title: str, year: int | None = None) -> MetadataResult:
         params: dict[str, Any] = {"query": title}
         if year is not None:
@@ -34,7 +74,9 @@ class TMDBClient:
     async def search_tv(self, title: str) -> MetadataResult:
         return await self._search("tv", {"query": title}, kind="tv")
 
-    async def search_movie_candidates(self, title: str, year: int | None = None, limit: int = 10) -> list[MetadataResult]:
+    async def search_movie_candidates(
+        self, title: str, year: int | None = None, limit: int = 10
+    ) -> list[MetadataResult]:
         params: dict[str, Any] = {"query": title}
         if year is not None:
             params["year"] = year
@@ -51,33 +93,12 @@ class TMDBClient:
         kind: Literal["movie", "tv"],
         limit: int,
     ) -> list[MetadataResult]:
-        try:
-            r = await self._http.get(f"{_BASE_URL}/search/{endpoint}", params=params, headers=self._headers)
-        except httpx.TimeoutException as e:
-            raise LookupTimeout(f"tmdb {endpoint} timeout") from e
-        except httpx.HTTPError as e:
-            raise LookupError(f"tmdb {endpoint} transport error: {e}") from e
-
-        if r.status_code == 401:
-            logger.warning("tmdb auth_failed status=401")
-            raise LookupError("tmdb auth failed")
-        if r.status_code >= 500:
-            raise LookupError(f"tmdb {endpoint} 5xx status={r.status_code}")
-        if r.status_code != 200:
-            raise LookupError(f"tmdb {endpoint} status={r.status_code}")
-
+        results = await self._get_results(endpoint, params)
         out: list[MetadataResult] = []
-        for top in (r.json().get("results") or [])[:limit]:
-            if endpoint == "movie":
-                release = top.get("release_date") or ""
-                title_val = top.get("title") or top.get("original_title") or ""
-            else:
-                release = top.get("first_air_date") or ""
-                title_val = top.get("name") or top.get("original_name") or ""
-            if not title_val:
-                continue
-            year_val = int(release[:4]) if release[:4].isdigit() else None
-            out.append(MetadataResult(title=title_val, year=year_val, kind=kind, payload=top))
+        for top in results[:limit]:
+            parsed = self._parse_one(top, endpoint, kind)
+            if parsed is not None:
+                out.append(parsed)
         return out
 
     async def _search(
@@ -87,41 +108,10 @@ class TMDBClient:
         *,
         kind: Literal["movie", "tv"],
     ) -> MetadataResult:
-        try:
-            r = await self._http.get(
-                f"{_BASE_URL}/search/{endpoint}",
-                params=params,
-                headers=self._headers,
-            )
-        except httpx.TimeoutException as e:
-            raise LookupTimeout(f"tmdb {endpoint} timeout") from e
-        except httpx.HTTPError as e:
-            raise LookupError(f"tmdb {endpoint} transport error: {e}") from e
-
-        if r.status_code == 401:
-            logger.warning("tmdb auth_failed status=401")
-            raise LookupError("tmdb auth failed")
-        if r.status_code >= 500:
-            raise LookupError(f"tmdb {endpoint} 5xx status={r.status_code}")
-        if r.status_code != 200:
-            raise LookupError(f"tmdb {endpoint} status={r.status_code}")
-
-        body = r.json()
-        results = body.get("results") or []
+        results = await self._get_results(endpoint, params)
         if not results:
             raise LookupError(f"tmdb {endpoint} no results")
-
-        top = results[0]
-        if endpoint == "movie":
-            release = top.get("release_date") or ""
-            year_val = int(release[:4]) if release[:4].isdigit() else None
-            title_val = top.get("title") or top.get("original_title") or ""
-        else:
-            release = top.get("first_air_date") or ""
-            year_val = int(release[:4]) if release[:4].isdigit() else None
-            title_val = top.get("name") or top.get("original_name") or ""
-
-        if not title_val:
+        parsed = self._parse_one(results[0], endpoint, kind)
+        if parsed is None:
             raise LookupError(f"tmdb {endpoint} top result missing title")
-
-        return MetadataResult(title=title_val, year=year_val, kind=kind, payload=top)
+        return parsed

--- a/services/backend/arm_backend/metadata/tmdb.py
+++ b/services/backend/arm_backend/metadata/tmdb.py
@@ -34,6 +34,52 @@ class TMDBClient:
     async def search_tv(self, title: str) -> MetadataResult:
         return await self._search("tv", {"query": title}, kind="tv")
 
+    async def search_movie_candidates(self, title: str, year: int | None = None, limit: int = 10) -> list[MetadataResult]:
+        params: dict[str, Any] = {"query": title}
+        if year is not None:
+            params["year"] = year
+        return await self._search_candidates("movie", params, kind="movie", limit=limit)
+
+    async def search_tv_candidates(self, title: str, limit: int = 10) -> list[MetadataResult]:
+        return await self._search_candidates("tv", {"query": title}, kind="tv", limit=limit)
+
+    async def _search_candidates(
+        self,
+        endpoint: str,
+        params: dict[str, Any],
+        *,
+        kind: Literal["movie", "tv"],
+        limit: int,
+    ) -> list[MetadataResult]:
+        try:
+            r = await self._http.get(f"{_BASE_URL}/search/{endpoint}", params=params, headers=self._headers)
+        except httpx.TimeoutException as e:
+            raise LookupTimeout(f"tmdb {endpoint} timeout") from e
+        except httpx.HTTPError as e:
+            raise LookupError(f"tmdb {endpoint} transport error: {e}") from e
+
+        if r.status_code == 401:
+            logger.warning("tmdb auth_failed status=401")
+            raise LookupError("tmdb auth failed")
+        if r.status_code >= 500:
+            raise LookupError(f"tmdb {endpoint} 5xx status={r.status_code}")
+        if r.status_code != 200:
+            raise LookupError(f"tmdb {endpoint} status={r.status_code}")
+
+        out: list[MetadataResult] = []
+        for top in (r.json().get("results") or [])[:limit]:
+            if endpoint == "movie":
+                release = top.get("release_date") or ""
+                title_val = top.get("title") or top.get("original_title") or ""
+            else:
+                release = top.get("first_air_date") or ""
+                title_val = top.get("name") or top.get("original_name") or ""
+            if not title_val:
+                continue
+            year_val = int(release[:4]) if release[:4].isdigit() else None
+            out.append(MetadataResult(title=title_val, year=year_val, kind=kind, payload=top))
+        return out
+
     async def _search(
         self,
         endpoint: str,

--- a/services/backend/arm_backend/routers/metadata.py
+++ b/services/backend/arm_backend/routers/metadata.py
@@ -5,6 +5,7 @@ GET /api/v1/metadata/test-key."""
 
 import logging
 import re
+from typing import Literal
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -13,11 +14,16 @@ from sqlmodel import col, select
 
 from arm_backend.auth import require_jwt
 from arm_backend.db import get_session
+from arm_backend.metadata.arm_server import ArmServerClient
 from arm_backend.metadata.base import LookupError as MetaLookupError
+from arm_backend.metadata.base import LookupTimeout, MetadataResult, extract_poster_url
+from arm_backend.metadata.musicbrainz import MusicBrainzClient
+from arm_backend.metadata.omdb import OMDBClient
+from arm_backend.metadata.tmdb import TMDBClient
 from arm_backend.metadata.tvdb import TVDBClient
 from arm_backend.seeders import CONFIG_SINGLETON_ID
 from arm_common import Config, User
-from arm_common.schemas import MetadataKeyTestResponse, MetadataProvider
+from arm_common.schemas import MetadataCandidate, MetadataKeyTestResponse, MetadataProvider, MetadataSearchResponse
 
 logger = logging.getLogger("arm_backend.routers.metadata")
 
@@ -93,3 +99,104 @@ async def test_key(
         return MetadataKeyTestResponse(provider=provider, valid=False, detail=f"transport error: {exc}")
 
     return MetadataKeyTestResponse(provider=provider, valid=True, detail=None)
+
+
+# ---------------------------------------------------------------------------
+# Search / lookup / music endpoints
+# ---------------------------------------------------------------------------
+
+SearchType = Literal["movie", "tv"]
+SearchProvider = Literal["tmdb", "omdb"]
+
+
+def _to_candidate(r: MetadataResult) -> MetadataCandidate:
+    payload = r.payload or {}
+    provider_id = payload.get("id") or payload.get("imdbID")
+    return MetadataCandidate(
+        title=r.title,
+        year=r.year,
+        kind=r.kind,
+        poster_url=extract_poster_url(r),
+        provider_id=str(provider_id) if provider_id is not None else None,
+    )
+
+
+@router.get("/search", response_model=MetadataSearchResponse)
+async def search_metadata(
+    request: Request,
+    title: str,
+    type: SearchType = "movie",
+    provider: SearchProvider = "tmdb",
+    _: User = Depends(require_jwt),
+    db: AsyncSession = Depends(get_session),
+) -> MetadataSearchResponse:
+    cfg = (await db.execute(select(Config).where(col(Config.id) == CONFIG_SINGLETON_ID))).scalar_one_or_none()
+    if cfg is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="config not initialised")
+    http: httpx.AsyncClient = request.app.state.http
+    key = (cfg.tmdb_api_key if provider == "tmdb" else cfg.omdb_api_key) or ""
+    if not key.strip():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"no {provider} key configured")
+    try:
+        if provider == "tmdb":
+            client = TMDBClient(key, http)
+            results = await (client.search_movie_candidates(title) if type == "movie" else client.search_tv_candidates(title))
+        else:
+            results = await OMDBClient(key, http).search_candidates(title, kind=type)
+    except (MetaLookupError, LookupTimeout) as exc:
+        return MetadataSearchResponse(candidates=[], detail=str(exc))
+    except httpx.HTTPError as exc:
+        return MetadataSearchResponse(candidates=[], detail=f"{provider} unavailable: {exc}")
+    return MetadataSearchResponse(candidates=[_to_candidate(r) for r in results])
+
+
+@router.get("/lookup", response_model=MetadataSearchResponse)
+async def lookup_metadata(
+    request: Request,
+    imdb_id: str | None = None,
+    crc64: str | None = None,
+    _: User = Depends(require_jwt),
+    db: AsyncSession = Depends(get_session),
+) -> MetadataSearchResponse:
+    if (imdb_id is None) == (crc64 is None):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="exactly one of imdb_id or crc64 is required",
+        )
+    cfg = (await db.execute(select(Config).where(col(Config.id) == CONFIG_SINGLETON_ID))).scalar_one_or_none()
+    if cfg is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="config not initialised")
+    http: httpx.AsyncClient = request.app.state.http
+    if imdb_id is not None:
+        key = (cfg.omdb_api_key or "").strip()
+        if not key:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="no omdb key configured")
+    try:
+        if imdb_id is not None:
+            result = await OMDBClient(key, http).lookup_by_imdb_id(imdb_id)  # type: ignore[possibly-undefined]
+        else:
+            result = await ArmServerClient(http).lookup_by_crc64(crc64)  # type: ignore[arg-type]
+    except (MetaLookupError, LookupTimeout) as exc:
+        return MetadataSearchResponse(candidates=[], detail=str(exc))
+    except httpx.HTTPError as exc:
+        return MetadataSearchResponse(candidates=[], detail=f"lookup unavailable: {exc}")
+    return MetadataSearchResponse(candidates=[_to_candidate(result)])
+
+
+@router.get("/music/search", response_model=MetadataSearchResponse)
+async def search_music(
+    request: Request,
+    query: str,
+    _: User = Depends(require_jwt),
+    db: AsyncSession = Depends(get_session),
+) -> MetadataSearchResponse:
+    cfg = (await db.execute(select(Config).where(col(Config.id) == CONFIG_SINGLETON_ID))).scalar_one_or_none()
+    ua = (cfg.musicbrainz_user_agent if cfg else None) or "armv3"
+    http: httpx.AsyncClient = request.app.state.http
+    try:
+        results = await MusicBrainzClient(ua, http).search_releases(query)
+    except (MetaLookupError, LookupTimeout) as exc:
+        return MetadataSearchResponse(candidates=[], detail=str(exc))
+    except httpx.HTTPError as exc:
+        return MetadataSearchResponse(candidates=[], detail=f"musicbrainz unavailable: {exc}")
+    return MetadataSearchResponse(candidates=[_to_candidate(r) for r in results])

--- a/services/backend/arm_backend/routers/metadata.py
+++ b/services/backend/arm_backend/routers/metadata.py
@@ -203,3 +203,29 @@ async def search_music(
     except httpx.HTTPError as exc:
         return MetadataSearchResponse(candidates=[], detail=f"musicbrainz unavailable: {exc}")
     return MetadataSearchResponse(candidates=[_to_candidate(r) for r in results])
+
+
+@router.get("/music/{release_id}", response_model=MetadataCandidate)
+async def music_release_detail(
+    release_id: str,
+    request: Request,
+    _: User = Depends(require_jwt),
+    db: AsyncSession = Depends(get_session),
+) -> MetadataCandidate:
+    cfg = (await db.execute(select(Config).where(col(Config.id) == CONFIG_SINGLETON_ID))).scalar_one_or_none()
+    ua = (cfg.musicbrainz_user_agent if cfg else None) or "armv3"
+    http: httpx.AsyncClient = request.app.state.http
+    try:
+        result = await MusicBrainzClient(ua, http).get_release(release_id)
+    except MetaLookupError as exc:
+        # _get collapses both a real 404 (unknown MBID) and transport failures
+        # into LookupError, so we discriminate on the message: the not-found
+        # path carries the `not_found_detail` string ("...release not found")
+        # → 404; anything else (transport / 5xx / bad status) is an upstream
+        # outage → 502.
+        if "not found" in str(exc):
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=f"musicbrainz unavailable: {exc}") from exc
+    except (LookupTimeout, httpx.HTTPError) as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=f"musicbrainz unavailable: {exc}") from exc
+    return _to_candidate(result)

--- a/services/backend/arm_backend/routers/metadata.py
+++ b/services/backend/arm_backend/routers/metadata.py
@@ -23,7 +23,14 @@ from arm_backend.metadata.tmdb import TMDBClient
 from arm_backend.metadata.tvdb import TVDBClient
 from arm_backend.seeders import CONFIG_SINGLETON_ID
 from arm_common import Config, User
-from arm_common.schemas import MetadataCandidate, MetadataKeyTestResponse, MetadataProvider, MetadataSearchResponse
+from arm_common.schemas import (
+    MetadataCandidate,
+    MetadataKeyTestResponse,
+    MetadataProvider,
+    MetadataReleaseDetail,
+    MetadataReleaseTrack,
+    MetadataSearchResponse,
+)
 
 logger = logging.getLogger("arm_backend.routers.metadata")
 
@@ -205,13 +212,13 @@ async def search_music(
     return MetadataSearchResponse(candidates=[_to_candidate(r) for r in results])
 
 
-@router.get("/music/{release_id}", response_model=MetadataCandidate)
+@router.get("/music/{release_id}", response_model=MetadataReleaseDetail)
 async def music_release_detail(
     release_id: str,
     request: Request,
     _: User = Depends(require_jwt),
     db: AsyncSession = Depends(get_session),
-) -> MetadataCandidate:
+) -> MetadataReleaseDetail:
     cfg = (await db.execute(select(Config).where(col(Config.id) == CONFIG_SINGLETON_ID))).scalar_one_or_none()
     ua = (cfg.musicbrainz_user_agent if cfg else None) or "armv3"
     http: httpx.AsyncClient = request.app.state.http
@@ -228,4 +235,14 @@ async def music_release_detail(
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=f"musicbrainz unavailable: {exc}") from exc
     except (LookupTimeout, httpx.HTTPError) as exc:
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=f"musicbrainz unavailable: {exc}") from exc
-    return _to_candidate(result)
+    payload = result.payload or {}
+    raw_tracks = payload.get("tracks") or []
+    tracks = [MetadataReleaseTrack(position=t.get("position"), title=t.get("title") or "") for t in raw_tracks]
+    return MetadataReleaseDetail(
+        release_id=release_id,
+        title=result.title,
+        artist=payload.get("artist"),
+        year=result.year,
+        poster_url=extract_poster_url(result),
+        tracks=tracks,
+    )

--- a/services/backend/arm_backend/routers/metadata.py
+++ b/services/backend/arm_backend/routers/metadata.py
@@ -140,7 +140,9 @@ async def search_metadata(
     try:
         if provider == "tmdb":
             client = TMDBClient(key, http)
-            results = await (client.search_movie_candidates(title) if type == "movie" else client.search_tv_candidates(title))
+            results = await (
+                client.search_movie_candidates(title) if type == "movie" else client.search_tv_candidates(title)
+            )
         else:
             results = await OMDBClient(key, http).search_candidates(title, kind=type)
     except (MetaLookupError, LookupTimeout) as exc:
@@ -163,18 +165,19 @@ async def lookup_metadata(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="exactly one of imdb_id or crc64 is required",
         )
-    cfg = (await db.execute(select(Config).where(col(Config.id) == CONFIG_SINGLETON_ID))).scalar_one_or_none()
-    if cfg is None:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="config not initialised")
     http: httpx.AsyncClient = request.app.state.http
-    if imdb_id is not None:
-        key = (cfg.omdb_api_key or "").strip()
-        if not key:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="no omdb key configured")
     try:
         if imdb_id is not None:
-            result = await OMDBClient(key, http).lookup_by_imdb_id(imdb_id)  # type: ignore[possibly-undefined]
+            # imdb lookup needs the OMDB key from config; crc64 (community DB)
+            # needs no key or config, so its guard lives in this branch only.
+            cfg = (await db.execute(select(Config).where(col(Config.id) == CONFIG_SINGLETON_ID))).scalar_one_or_none()
+            key = (cfg.omdb_api_key or "").strip() if cfg is not None else ""
+            if not key:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="no omdb key configured")
+            result = await OMDBClient(key, http).lookup_by_imdb_id(imdb_id)
         else:
+            # The XOR guard above guarantees crc64 is a str in this branch,
+            # but mypy can't narrow it across the if/else.
             result = await ArmServerClient(http).lookup_by_crc64(crc64)  # type: ignore[arg-type]
     except (MetaLookupError, LookupTimeout) as exc:
         return MetadataSearchResponse(candidates=[], detail=str(exc))

--- a/services/backend/tests/test_metadata_clients.py
+++ b/services/backend/tests/test_metadata_clients.py
@@ -495,30 +495,6 @@ async def test_omdb_lookup_by_title_missing_title_raises(http_client):
         await client.lookup_by_title("x")
 
 
-@respx.mock
-async def test_omdb_lookup_by_title_with_year_param(http_client):
-    """Exercises the `if year is not None: params['y'] = year` branch."""
-    from arm_backend.metadata.omdb import OMDBClient
-    respx.get("https://www.omdbapi.com/").mock(
-        return_value=httpx.Response(200, json={"Response": "True", "Title": "Blade Runner", "Year": "1982"})
-    )
-    client = OMDBClient("k", http_client)
-    result = await client.lookup_by_title("Blade Runner", year=1982)
-    assert result.year == 1982
-
-
-@respx.mock
-async def test_omdb_lookup_by_title_non_digit_year(http_client):
-    """Year field that can't be parsed as int yields year=None."""
-    from arm_backend.metadata.omdb import OMDBClient
-    respx.get("https://www.omdbapi.com/").mock(
-        return_value=httpx.Response(200, json={"Response": "True", "Title": "Old Film", "Year": "N/A"})
-    )
-    client = OMDBClient("k", http_client)
-    result = await client.lookup_by_title("Old Film")
-    assert result.year is None
-
-
 # ---------------------------------------------------------------------------
 # Coverage gap tests — search_candidates error branches
 # ---------------------------------------------------------------------------
@@ -682,15 +658,3 @@ async def test_omdb_lookup_by_imdb_id_tv_series_kind(http_client):
     assert result.kind == "tv"
 
 
-@respx.mock
-async def test_omdb_lookup_by_imdb_id_non_digit_year(http_client):
-    """Year field that can't be parsed yields year=None."""
-    from arm_backend.metadata.omdb import OMDBClient
-    respx.get("https://www.omdbapi.com/").mock(
-        return_value=httpx.Response(200, json={
-            "Response": "True", "Title": "Some Show", "Year": "N/A", "Type": "movie",
-        })
-    )
-    client = OMDBClient("k", http_client)
-    result = await client.lookup_by_imdb_id("tt0000001")
-    assert result.year is None

--- a/services/backend/tests/test_metadata_clients.py
+++ b/services/backend/tests/test_metadata_clients.py
@@ -499,50 +499,10 @@ async def test_omdb_lookup_by_title_missing_title_raises(http_client):
 # Coverage gap tests — search_candidates error branches
 # ---------------------------------------------------------------------------
 
-@respx.mock
-async def test_omdb_search_candidates_timeout_raises(http_client):
-    from arm_backend.metadata.omdb import OMDBClient
-    from arm_backend.metadata.base import LookupTimeout
-
-    def _raise_timeout(request):
-        raise httpx.TimeoutException("timed out", request=request)
-
-    respx.get("https://www.omdbapi.com/").mock(side_effect=_raise_timeout)
-    client = OMDBClient("k", http_client)
-    with pytest.raises(LookupTimeout):
-        await client.search_candidates("x")
-
-
-@respx.mock
-async def test_omdb_search_candidates_transport_error_raises(http_client):
-    from arm_backend.metadata.omdb import OMDBClient
-
-    def _raise_transport(request):
-        raise httpx.ConnectError("conn refused", request=request)
-
-    respx.get("https://www.omdbapi.com/").mock(side_effect=_raise_transport)
-    client = OMDBClient("k", http_client)
-    with pytest.raises(LookupError):
-        await client.search_candidates("x")
-
-
-@respx.mock
-async def test_omdb_search_candidates_5xx_raises(http_client):
-    from arm_backend.metadata.omdb import OMDBClient
-    respx.get("https://www.omdbapi.com/").mock(return_value=httpx.Response(500))
-    client = OMDBClient("k", http_client)
-    with pytest.raises(LookupError, match="5xx"):
-        await client.search_candidates("x")
-
-
-@respx.mock
-async def test_omdb_search_candidates_non200_raises(http_client):
-    from arm_backend.metadata.omdb import OMDBClient
-    respx.get("https://www.omdbapi.com/").mock(return_value=httpx.Response(404))
-    client = OMDBClient("k", http_client)
-    with pytest.raises(LookupError, match="omdb status=404"):
-        await client.search_candidates("x")
-
+# Note: the shared transport/status branches (timeout, transport error, 401,
+# 5xx, non-200) live in OMDBClient._get_json and are covered once by the
+# lookup_by_title_*_raises tests above. search_candidates / lookup_by_imdb_id
+# only need their own BEHAVIOR tests (empty-vs-raise, skip, kind inference).
 
 @respx.mock
 async def test_omdb_search_candidates_skips_items_without_title(http_client):
@@ -562,64 +522,6 @@ async def test_omdb_search_candidates_skips_items_without_title(http_client):
     results = await client.search_candidates("real", kind="movie")
     assert len(results) == 1
     assert results[0].title == "Real Movie"
-
-
-# ---------------------------------------------------------------------------
-# Coverage gap tests — lookup_by_imdb_id error branches
-# ---------------------------------------------------------------------------
-
-@respx.mock
-async def test_omdb_lookup_by_imdb_id_timeout_raises(http_client):
-    from arm_backend.metadata.omdb import OMDBClient
-    from arm_backend.metadata.base import LookupTimeout
-
-    def _raise_timeout(request):
-        raise httpx.TimeoutException("timed out", request=request)
-
-    respx.get("https://www.omdbapi.com/").mock(side_effect=_raise_timeout)
-    client = OMDBClient("k", http_client)
-    with pytest.raises(LookupTimeout):
-        await client.lookup_by_imdb_id("tt0133093")
-
-
-@respx.mock
-async def test_omdb_lookup_by_imdb_id_transport_error_raises(http_client):
-    from arm_backend.metadata.omdb import OMDBClient
-
-    def _raise_transport(request):
-        raise httpx.ConnectError("conn refused", request=request)
-
-    respx.get("https://www.omdbapi.com/").mock(side_effect=_raise_transport)
-    client = OMDBClient("k", http_client)
-    with pytest.raises(LookupError):
-        await client.lookup_by_imdb_id("tt0133093")
-
-
-@respx.mock
-async def test_omdb_lookup_by_imdb_id_401_raises(http_client):
-    from arm_backend.metadata.omdb import OMDBClient
-    respx.get("https://www.omdbapi.com/").mock(return_value=httpx.Response(401))
-    client = OMDBClient("k", http_client)
-    with pytest.raises(LookupError, match="omdb auth failed"):
-        await client.lookup_by_imdb_id("tt0133093")
-
-
-@respx.mock
-async def test_omdb_lookup_by_imdb_id_5xx_raises(http_client):
-    from arm_backend.metadata.omdb import OMDBClient
-    respx.get("https://www.omdbapi.com/").mock(return_value=httpx.Response(503))
-    client = OMDBClient("k", http_client)
-    with pytest.raises(LookupError, match="5xx"):
-        await client.lookup_by_imdb_id("tt0133093")
-
-
-@respx.mock
-async def test_omdb_lookup_by_imdb_id_non200_raises(http_client):
-    from arm_backend.metadata.omdb import OMDBClient
-    respx.get("https://www.omdbapi.com/").mock(return_value=httpx.Response(404))
-    client = OMDBClient("k", http_client)
-    with pytest.raises(LookupError, match="omdb status=404"):
-        await client.lookup_by_imdb_id("tt0133093")
 
 
 @respx.mock

--- a/services/backend/tests/test_metadata_clients.py
+++ b/services/backend/tests/test_metadata_clients.py
@@ -765,3 +765,82 @@ async def test_tmdb_search_movie_candidates_with_year(http_client):
     results = await client.search_movie_candidates("dune", year=2021)
     assert results[0].title == "Dune"
     assert "year=2021" in str(respx.calls.last.request.url)
+
+
+# ---------------------------------------------------------------------------
+# MusicBrainz release search
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_musicbrainz_search_releases(http_client):
+    respx.get("https://musicbrainz.org/ws/2/release").mock(
+        return_value=httpx.Response(200, json={"releases": [
+            {"title": "The Dark Side of the Moon", "date": "1973-03-01", "id": "mb-1",
+             "artist-credit": [{"name": "Pink Floyd"}]},
+        ]})
+    )
+    client = MusicBrainzClient("arm/test", http_client)
+    results = await client.search_releases("dark side of the moon")
+    assert results[0].title == "The Dark Side of the Moon"
+    assert results[0].year == 1973
+    assert results[0].kind == "music"
+    assert results[0].payload["artist"] == "Pink Floyd"
+
+
+@respx.mock
+async def test_musicbrainz_search_empty(http_client):
+    respx.get("https://musicbrainz.org/ws/2/release").mock(
+        return_value=httpx.Response(200, json={"releases": []})
+    )
+    client = MusicBrainzClient("arm/test", http_client)
+    assert await client.search_releases("zzz") == []
+
+
+@respx.mock
+async def test_musicbrainz_search_5xx_raises(http_client):
+    respx.get("https://musicbrainz.org/ws/2/release").mock(return_value=httpx.Response(503))
+    client = MusicBrainzClient("arm/test", http_client)
+    with pytest.raises(LookupError):
+        await client.search_releases("x")
+
+
+@respx.mock
+async def test_musicbrainz_search_skips_releases_without_title(http_client):
+    """Releases missing the title key are silently skipped."""
+    respx.get("https://musicbrainz.org/ws/2/release").mock(
+        return_value=httpx.Response(200, json={"releases": [
+            {"date": "2000-01-01", "id": "mb-no-title"},  # no title key
+            {"title": "", "date": "2001-01-01", "id": "mb-empty-title"},  # empty title
+            {"title": "Real Album", "date": "2002-06-15", "id": "mb-real"},
+        ]})
+    )
+    client = MusicBrainzClient("arm/test", http_client)
+    results = await client.search_releases("real")
+    assert len(results) == 1
+    assert results[0].title == "Real Album"
+
+
+@respx.mock
+async def test_musicbrainz_search_timeout_raises(http_client):
+    from arm_backend.metadata.base import LookupTimeout
+
+    def _raise_timeout(request):
+        raise httpx.TimeoutException("timed out", request=request)
+
+    respx.get("https://musicbrainz.org/ws/2/release").mock(side_effect=_raise_timeout)
+    client = MusicBrainzClient("arm/test", http_client)
+    with pytest.raises(LookupTimeout):
+        await client.search_releases("x")
+
+
+@respx.mock
+async def test_musicbrainz_transport_error_raises(http_client):
+    # Covers the shared _get HTTPError branch (non-timeout transport failure).
+    def _raise_transport(request):
+        raise httpx.ConnectError("conn refused", request=request)
+
+    respx.get("https://musicbrainz.org/ws/2/release").mock(side_effect=_raise_transport)
+    client = MusicBrainzClient("arm/test", http_client)
+    with pytest.raises(LookupError, match="transport error"):
+        await client.search_releases("x")

--- a/services/backend/tests/test_metadata_clients.py
+++ b/services/backend/tests/test_metadata_clients.py
@@ -2,7 +2,7 @@ import httpx
 import pytest
 import respx
 
-from arm_backend.metadata.base import LookupError
+from arm_backend.metadata.base import LookupError, LookupTimeout
 from arm_backend.metadata.musicbrainz import MusicBrainzClient
 from arm_backend.metadata.omdb import OMDBClient
 from arm_backend.metadata.tmdb import TMDBClient
@@ -441,7 +441,6 @@ async def test_omdb_lookup_by_imdb_id(http_client):
 
 @respx.mock
 async def test_omdb_lookup_by_title_timeout_raises(http_client):
-    from arm_backend.metadata.base import LookupTimeout
 
     def _raise_timeout(request):
         raise httpx.TimeoutException("timed out", request=request)
@@ -673,7 +672,6 @@ async def test_tmdb_get_results_5xx_raises(http_client):
 
 @respx.mock
 async def test_tmdb_get_results_timeout_raises(http_client):
-    from arm_backend.metadata.base import LookupTimeout
 
     def _raise_timeout(request):
         raise httpx.TimeoutException("timed out", request=request)
@@ -808,7 +806,7 @@ async def test_musicbrainz_search_empty(http_client):
 async def test_musicbrainz_search_5xx_raises(http_client):
     respx.get("https://musicbrainz.org/ws/2/release").mock(return_value=httpx.Response(503))
     client = MusicBrainzClient("arm/test", http_client)
-    with pytest.raises(LookupError):
+    with pytest.raises(LookupError, match="5xx"):
         await client.search_releases("x")
 
 
@@ -835,7 +833,6 @@ async def test_musicbrainz_search_skips_releases_without_title(http_client):
 
 @respx.mock
 async def test_musicbrainz_search_timeout_raises(http_client):
-    from arm_backend.metadata.base import LookupTimeout
 
     def _raise_timeout(request):
         raise httpx.TimeoutException("timed out", request=request)

--- a/services/backend/tests/test_metadata_clients.py
+++ b/services/backend/tests/test_metadata_clients.py
@@ -892,3 +892,37 @@ async def test_musicbrainz_disc_id_top_release_missing_title_raises(http_client)
     client = MusicBrainzClient("arm/test", http_client)
     with pytest.raises(LookupError, match="missing title"):
         await client.lookup_disc_id("abc")
+
+
+# ---------------------------------------------------------------------------
+# MusicBrainz release detail (by MBID)
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_get_release_success(http_client):
+    respx.get("https://musicbrainz.org/ws/2/release/mbid-1").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "mbid-1",
+                "title": "The Dark Side of the Moon",
+                "date": "1973-03-01",
+                "artist-credit": [{"name": "Pink Floyd"}],
+                "media": [{"tracks": [{"position": "1", "title": "Speak to Me"}]}],
+            },
+        )
+    )
+    result = await MusicBrainzClient("armv3", http_client).get_release("mbid-1")
+    assert result.title == "The Dark Side of the Moon"
+    assert result.year == 1973
+    assert result.kind == "music"
+    assert result.payload["artist"] == "Pink Floyd"
+    assert result.payload["tracks"] == [{"title": "Speak to Me", "position": 1}]
+
+
+@respx.mock
+async def test_get_release_not_found(http_client):
+    respx.get("https://musicbrainz.org/ws/2/release/missing").mock(return_value=httpx.Response(404))
+    with pytest.raises(LookupError, match="release not found"):
+        await MusicBrainzClient("armv3", http_client).get_release("missing")

--- a/services/backend/tests/test_metadata_clients.py
+++ b/services/backend/tests/test_metadata_clients.py
@@ -585,10 +585,15 @@ async def test_omdb_lookup_by_imdb_id_tv_series_kind(http_client):
 @respx.mock
 async def test_tmdb_search_movie_candidates(http_client):
     respx.get("https://api.themoviedb.org/3/search/movie").mock(
-        return_value=httpx.Response(200, json={"results": [
-            {"title": "The Matrix", "release_date": "1999-03-31", "id": 603, "poster_path": "/a.jpg"},
-            {"title": "The Matrix Reloaded", "release_date": "2003-05-15", "id": 604, "poster_path": "/b.jpg"},
-        ]})
+        return_value=httpx.Response(
+            200,
+            json={
+                "results": [
+                    {"title": "The Matrix", "release_date": "1999-03-31", "id": 603, "poster_path": "/a.jpg"},
+                    {"title": "The Matrix Reloaded", "release_date": "2003-05-15", "id": 604, "poster_path": "/b.jpg"},
+                ]
+            },
+        )
     )
     client = TMDBClient("k", http_client)
     results = await client.search_movie_candidates("matrix")
@@ -600,9 +605,14 @@ async def test_tmdb_search_movie_candidates(http_client):
 @respx.mock
 async def test_tmdb_search_tv_candidates(http_client):
     respx.get("https://api.themoviedb.org/3/search/tv").mock(
-        return_value=httpx.Response(200, json={"results": [
-            {"name": "Battlestar Galactica", "first_air_date": "2004-10-18", "id": 1972},
-        ]})
+        return_value=httpx.Response(
+            200,
+            json={
+                "results": [
+                    {"name": "Battlestar Galactica", "first_air_date": "2004-10-18", "id": 1972},
+                ]
+            },
+        )
     )
     client = TMDBClient("k", http_client)
     results = await client.search_tv_candidates("galactica")
@@ -613,9 +623,7 @@ async def test_tmdb_search_tv_candidates(http_client):
 
 @respx.mock
 async def test_tmdb_search_empty_results(http_client):
-    respx.get("https://api.themoviedb.org/3/search/movie").mock(
-        return_value=httpx.Response(200, json={"results": []})
-    )
+    respx.get("https://api.themoviedb.org/3/search/movie").mock(return_value=httpx.Response(200, json={"results": []}))
     client = TMDBClient("k", http_client)
     assert await client.search_movie_candidates("zzz") == []
 
@@ -632,14 +640,128 @@ async def test_tmdb_search_auth_failure_raises(http_client):
 async def test_tmdb_search_candidates_skips_items_without_title(http_client):
     """Items with no usable title are silently skipped; tv path + original_name fallback exercised."""
     respx.get("https://api.themoviedb.org/3/search/tv").mock(
-        return_value=httpx.Response(200, json={"results": [
-            {"name": "", "first_air_date": "2000-01-01", "id": 1},          # empty name — skip
-            {"first_air_date": "2001-01-01", "id": 2},                       # missing name key — skip
-            {"original_name": "Fallback Show", "first_air_date": "2002-06-01", "id": 3},  # original_name fallback
-        ]})
+        return_value=httpx.Response(
+            200,
+            json={
+                "results": [
+                    {"name": "", "first_air_date": "2000-01-01", "id": 1},  # empty name — skip
+                    {"first_air_date": "2001-01-01", "id": 2},  # missing name key — skip
+                    {
+                        "original_name": "Fallback Show",
+                        "first_air_date": "2002-06-01",
+                        "id": 3,
+                    },  # original_name fallback
+                ]
+            },
+        )
     )
     client = TMDBClient("k", http_client)
     results = await client.search_tv_candidates("x")
     assert len(results) == 1
     assert results[0].title == "Fallback Show"
     assert results[0].year == 2002
+
+
+@respx.mock
+async def test_tmdb_get_results_5xx_raises(http_client):
+    # Covers the shared _get_results 5xx branch (used by both search paths).
+    respx.get("https://api.themoviedb.org/3/search/movie").mock(return_value=httpx.Response(503))
+    client = TMDBClient("k", http_client)
+    with pytest.raises(LookupError, match="5xx"):
+        await client.search_movie_candidates("x")
+
+
+@respx.mock
+async def test_tmdb_get_results_timeout_raises(http_client):
+    from arm_backend.metadata.base import LookupTimeout
+
+    def _raise_timeout(request):
+        raise httpx.TimeoutException("timed out", request=request)
+
+    respx.get("https://api.themoviedb.org/3/search/movie").mock(side_effect=_raise_timeout)
+    client = TMDBClient("k", http_client)
+    with pytest.raises(LookupTimeout):
+        await client.search_movie_candidates("x")
+
+
+@respx.mock
+async def test_tmdb_search_movie_top_hit_with_year(http_client):
+    # Covers single-hit search_movie + the year-param branch.
+    respx.get("https://api.themoviedb.org/3/search/movie").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "results": [
+                    {"title": "Iron Man", "release_date": "2008-05-02", "id": 1726},
+                ]
+            },
+        )
+    )
+    client = TMDBClient("k", http_client)
+    result = await client.search_movie("iron man", 2008)
+    assert result.title == "Iron Man"
+    assert result.year == 2008
+    assert "year=2008" in str(respx.calls.last.request.url)
+
+
+@respx.mock
+async def test_tmdb_search_tv_top_hit(http_client):
+    # Covers single-hit search_tv path.
+    respx.get("https://api.themoviedb.org/3/search/tv").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "results": [
+                    {"name": "The Expanse", "first_air_date": "2015-12-14", "id": 63639},
+                ]
+            },
+        )
+    )
+    client = TMDBClient("k", http_client)
+    result = await client.search_tv("expanse")
+    assert result.title == "The Expanse"
+    assert result.kind == "tv"
+
+
+@respx.mock
+async def test_tmdb_search_top_result_missing_title_raises(http_client):
+    # Covers the _search "top result missing title" branch.
+    respx.get("https://api.themoviedb.org/3/search/movie").mock(
+        return_value=httpx.Response(200, json={"results": [{"release_date": "1999-01-01", "id": 1}]})
+    )
+    client = TMDBClient("k", http_client)
+    with pytest.raises(LookupError, match="missing title"):
+        await client.search_movie("x")
+
+
+@respx.mock
+async def test_tmdb_get_results_transport_error_raises(http_client):
+    # Covers the shared _get_results HTTPError (non-timeout transport) branch.
+    def _raise_transport(request):
+        raise httpx.ConnectError("conn refused", request=request)
+
+    respx.get("https://api.themoviedb.org/3/search/movie").mock(side_effect=_raise_transport)
+    client = TMDBClient("k", http_client)
+    with pytest.raises(LookupError, match="transport error"):
+        await client.search_movie_candidates("x")
+
+
+@respx.mock
+async def test_tmdb_get_results_non200_raises(http_client):
+    # Covers the shared _get_results non-200 (non-401, non-5xx) branch.
+    respx.get("https://api.themoviedb.org/3/search/movie").mock(return_value=httpx.Response(404))
+    client = TMDBClient("k", http_client)
+    with pytest.raises(LookupError, match="status=404"):
+        await client.search_movie_candidates("x")
+
+
+@respx.mock
+async def test_tmdb_search_movie_candidates_with_year(http_client):
+    # Covers the year-param branch in search_movie_candidates.
+    respx.get("https://api.themoviedb.org/3/search/movie").mock(
+        return_value=httpx.Response(200, json={"results": [{"title": "Dune", "release_date": "2021-09-15", "id": 1}]})
+    )
+    client = TMDBClient("k", http_client)
+    results = await client.search_movie_candidates("dune", year=2021)
+    assert results[0].title == "Dune"
+    assert "year=2021" in str(respx.calls.last.request.url)

--- a/services/backend/tests/test_metadata_clients.py
+++ b/services/backend/tests/test_metadata_clients.py
@@ -375,20 +375,24 @@ async def test_musicbrainz_tracks_drop_entries_without_title(http_client):
 @respx.mock
 async def test_omdb_search_candidates(http_client):
     respx.get("https://www.omdbapi.com/").mock(
-        return_value=httpx.Response(200, json={
-            "Response": "True",
-            "Search": [
-                {"Title": "The Matrix", "Year": "1999", "imdbID": "tt0133093", "Poster": "http://x/p.jpg"},
-                {"Title": "The Matrix Reloaded", "Year": "2003", "imdbID": "tt0234215", "Poster": "N/A"},
-            ],
-        })
+        return_value=httpx.Response(
+            200,
+            json={
+                "Response": "True",
+                "Search": [
+                    {"Title": "The Matrix", "Year": "1999", "imdbID": "tt0133093", "Poster": "http://x/p.jpg"},
+                    {"Title": "The Matrix Reloaded", "Year": "2003", "imdbID": "tt0234215", "Poster": "N/A"},
+                ],
+            },
+        )
     )
-    from arm_backend.metadata.omdb import OMDBClient
     client = OMDBClient("k", http_client)
     results = await client.search_candidates("matrix", kind="movie")
     assert [r.title for r in results] == ["The Matrix", "The Matrix Reloaded"]
     assert results[0].year == 1999
     assert results[0].payload["imdbID"] == "tt0133093"
+    # search uses the OMDB `s=` param (not `t=`); guard against a future typo.
+    assert "s=matrix" in str(respx.calls.last.request.url)
 
 
 @respx.mock
@@ -396,7 +400,6 @@ async def test_omdb_search_no_results_returns_empty(http_client):
     respx.get("https://www.omdbapi.com/").mock(
         return_value=httpx.Response(200, json={"Response": "False", "Error": "Movie not found!"})
     )
-    from arm_backend.metadata.omdb import OMDBClient
     client = OMDBClient("k", http_client)
     results = await client.search_candidates("zzzznope", kind="movie")
     assert results == []
@@ -405,8 +408,6 @@ async def test_omdb_search_no_results_returns_empty(http_client):
 @respx.mock
 async def test_omdb_search_auth_failure_raises(http_client):
     respx.get("https://www.omdbapi.com/").mock(return_value=httpx.Response(401))
-    from arm_backend.metadata.omdb import OMDBClient
-    from arm_backend.metadata.base import LookupError
     client = OMDBClient("bad", http_client)
     with pytest.raises(LookupError):
         await client.search_candidates("matrix", kind="movie")
@@ -415,24 +416,31 @@ async def test_omdb_search_auth_failure_raises(http_client):
 @respx.mock
 async def test_omdb_lookup_by_imdb_id(http_client):
     respx.get("https://www.omdbapi.com/").mock(
-        return_value=httpx.Response(200, json={
-            "Response": "True", "Title": "The Matrix", "Year": "1999", "imdbID": "tt0133093",
-        })
+        return_value=httpx.Response(
+            200,
+            json={
+                "Response": "True",
+                "Title": "The Matrix",
+                "Year": "1999",
+                "imdbID": "tt0133093",
+            },
+        )
     )
-    from arm_backend.metadata.omdb import OMDBClient
     client = OMDBClient("k", http_client)
     result = await client.lookup_by_imdb_id("tt0133093")
     assert result.title == "The Matrix"
     assert result.year == 1999
+    # lookup uses the OMDB `i=` param; guard against a future typo.
+    assert "i=tt0133093" in str(respx.calls.last.request.url)
 
 
 # ---------------------------------------------------------------------------
 # Coverage gap tests — lookup_by_title error branches
 # ---------------------------------------------------------------------------
 
+
 @respx.mock
 async def test_omdb_lookup_by_title_timeout_raises(http_client):
-    from arm_backend.metadata.omdb import OMDBClient
     from arm_backend.metadata.base import LookupTimeout
 
     def _raise_timeout(request):
@@ -446,7 +454,6 @@ async def test_omdb_lookup_by_title_timeout_raises(http_client):
 
 @respx.mock
 async def test_omdb_lookup_by_title_transport_error_raises(http_client):
-    from arm_backend.metadata.omdb import OMDBClient
 
     def _raise_transport(request):
         raise httpx.ConnectError("conn refused", request=request)
@@ -459,7 +466,7 @@ async def test_omdb_lookup_by_title_transport_error_raises(http_client):
 
 @respx.mock
 async def test_omdb_lookup_by_title_401_raises(http_client):
-    from arm_backend.metadata.omdb import OMDBClient
+
     respx.get("https://www.omdbapi.com/").mock(return_value=httpx.Response(401))
     client = OMDBClient("k", http_client)
     with pytest.raises(LookupError, match="omdb auth failed"):
@@ -468,7 +475,7 @@ async def test_omdb_lookup_by_title_401_raises(http_client):
 
 @respx.mock
 async def test_omdb_lookup_by_title_5xx_raises(http_client):
-    from arm_backend.metadata.omdb import OMDBClient
+
     respx.get("https://www.omdbapi.com/").mock(return_value=httpx.Response(503))
     client = OMDBClient("k", http_client)
     with pytest.raises(LookupError, match="5xx"):
@@ -477,7 +484,7 @@ async def test_omdb_lookup_by_title_5xx_raises(http_client):
 
 @respx.mock
 async def test_omdb_lookup_by_title_non200_raises(http_client):
-    from arm_backend.metadata.omdb import OMDBClient
+
     respx.get("https://www.omdbapi.com/").mock(return_value=httpx.Response(404))
     client = OMDBClient("k", http_client)
     with pytest.raises(LookupError, match="omdb status=404"):
@@ -486,7 +493,7 @@ async def test_omdb_lookup_by_title_non200_raises(http_client):
 
 @respx.mock
 async def test_omdb_lookup_by_title_missing_title_raises(http_client):
-    from arm_backend.metadata.omdb import OMDBClient
+
     respx.get("https://www.omdbapi.com/").mock(
         return_value=httpx.Response(200, json={"Response": "True", "Title": "", "Year": "2000"})
     )
@@ -504,19 +511,23 @@ async def test_omdb_lookup_by_title_missing_title_raises(http_client):
 # lookup_by_title_*_raises tests above. search_candidates / lookup_by_imdb_id
 # only need their own BEHAVIOR tests (empty-vs-raise, skip, kind inference).
 
+
 @respx.mock
 async def test_omdb_search_candidates_skips_items_without_title(http_client):
     """Items in Search[] that have no Title are silently skipped."""
-    from arm_backend.metadata.omdb import OMDBClient
+
     respx.get("https://www.omdbapi.com/").mock(
-        return_value=httpx.Response(200, json={
-            "Response": "True",
-            "Search": [
-                {"Title": "", "Year": "2000", "imdbID": "tt0000001"},
-                {"Year": "2001", "imdbID": "tt0000002"},  # missing Title key
-                {"Title": "Real Movie", "Year": "2002", "imdbID": "tt0000003"},
-            ],
-        })
+        return_value=httpx.Response(
+            200,
+            json={
+                "Response": "True",
+                "Search": [
+                    {"Title": "", "Year": "2000", "imdbID": "tt0000001"},
+                    {"Year": "2001", "imdbID": "tt0000002"},  # missing Title key
+                    {"Title": "Real Movie", "Year": "2002", "imdbID": "tt0000003"},
+                ],
+            },
+        )
     )
     client = OMDBClient("k", http_client)
     results = await client.search_candidates("real", kind="movie")
@@ -526,7 +537,7 @@ async def test_omdb_search_candidates_skips_items_without_title(http_client):
 
 @respx.mock
 async def test_omdb_lookup_by_imdb_id_miss_raises(http_client):
-    from arm_backend.metadata.omdb import OMDBClient
+
     respx.get("https://www.omdbapi.com/").mock(
         return_value=httpx.Response(200, json={"Response": "False", "Error": "Incorrect IMDb ID."})
     )
@@ -537,7 +548,7 @@ async def test_omdb_lookup_by_imdb_id_miss_raises(http_client):
 
 @respx.mock
 async def test_omdb_lookup_by_imdb_id_missing_title_raises(http_client):
-    from arm_backend.metadata.omdb import OMDBClient
+
     respx.get("https://www.omdbapi.com/").mock(
         return_value=httpx.Response(200, json={"Response": "True", "Title": "", "Year": "2000"})
     )
@@ -549,14 +560,18 @@ async def test_omdb_lookup_by_imdb_id_missing_title_raises(http_client):
 @respx.mock
 async def test_omdb_lookup_by_imdb_id_tv_series_kind(http_client):
     """When OMDB returns Type=series, kind is set to 'tv'."""
-    from arm_backend.metadata.omdb import OMDBClient
+
     respx.get("https://www.omdbapi.com/").mock(
-        return_value=httpx.Response(200, json={
-            "Response": "True", "Title": "Breaking Bad", "Year": "2008", "Type": "series",
-        })
+        return_value=httpx.Response(
+            200,
+            json={
+                "Response": "True",
+                "Title": "Breaking Bad",
+                "Year": "2008",
+                "Type": "series",
+            },
+        )
     )
     client = OMDBClient("k", http_client)
     result = await client.lookup_by_imdb_id("tt0903747")
     assert result.kind == "tv"
-
-

--- a/services/backend/tests/test_metadata_clients.py
+++ b/services/backend/tests/test_metadata_clients.py
@@ -775,10 +775,19 @@ async def test_tmdb_search_movie_candidates_with_year(http_client):
 @respx.mock
 async def test_musicbrainz_search_releases(http_client):
     respx.get("https://musicbrainz.org/ws/2/release").mock(
-        return_value=httpx.Response(200, json={"releases": [
-            {"title": "The Dark Side of the Moon", "date": "1973-03-01", "id": "mb-1",
-             "artist-credit": [{"name": "Pink Floyd"}]},
-        ]})
+        return_value=httpx.Response(
+            200,
+            json={
+                "releases": [
+                    {
+                        "title": "The Dark Side of the Moon",
+                        "date": "1973-03-01",
+                        "id": "mb-1",
+                        "artist-credit": [{"name": "Pink Floyd"}],
+                    },
+                ]
+            },
+        )
     )
     client = MusicBrainzClient("arm/test", http_client)
     results = await client.search_releases("dark side of the moon")
@@ -790,9 +799,7 @@ async def test_musicbrainz_search_releases(http_client):
 
 @respx.mock
 async def test_musicbrainz_search_empty(http_client):
-    respx.get("https://musicbrainz.org/ws/2/release").mock(
-        return_value=httpx.Response(200, json={"releases": []})
-    )
+    respx.get("https://musicbrainz.org/ws/2/release").mock(return_value=httpx.Response(200, json={"releases": []}))
     client = MusicBrainzClient("arm/test", http_client)
     assert await client.search_releases("zzz") == []
 
@@ -809,11 +816,16 @@ async def test_musicbrainz_search_5xx_raises(http_client):
 async def test_musicbrainz_search_skips_releases_without_title(http_client):
     """Releases missing the title key are silently skipped."""
     respx.get("https://musicbrainz.org/ws/2/release").mock(
-        return_value=httpx.Response(200, json={"releases": [
-            {"date": "2000-01-01", "id": "mb-no-title"},  # no title key
-            {"title": "", "date": "2001-01-01", "id": "mb-empty-title"},  # empty title
-            {"title": "Real Album", "date": "2002-06-15", "id": "mb-real"},
-        ]})
+        return_value=httpx.Response(
+            200,
+            json={
+                "releases": [
+                    {"date": "2000-01-01", "id": "mb-no-title"},  # no title key
+                    {"title": "", "date": "2001-01-01", "id": "mb-empty-title"},  # empty title
+                    {"title": "Real Album", "date": "2002-06-15", "id": "mb-real"},
+                ]
+            },
+        )
     )
     client = MusicBrainzClient("arm/test", http_client)
     results = await client.search_releases("real")
@@ -844,3 +856,32 @@ async def test_musicbrainz_transport_error_raises(http_client):
     client = MusicBrainzClient("arm/test", http_client)
     with pytest.raises(LookupError, match="transport error"):
         await client.search_releases("x")
+
+
+@respx.mock
+async def test_musicbrainz_get_non200_raises(http_client):
+    # Covers the shared _get non-200 (non-5xx) branch.
+    respx.get("https://musicbrainz.org/ws/2/release").mock(return_value=httpx.Response(404))
+    client = MusicBrainzClient("arm/test", http_client)
+    with pytest.raises(LookupError, match="status=404"):
+        await client.search_releases("x")
+
+
+@respx.mock
+async def test_musicbrainz_disc_id_no_releases_raises(http_client):
+    # Covers lookup_disc_id's "no releases" branch.
+    respx.get("https://musicbrainz.org/ws/2/discid/abc").mock(return_value=httpx.Response(200, json={"releases": []}))
+    client = MusicBrainzClient("arm/test", http_client)
+    with pytest.raises(LookupError, match="no releases"):
+        await client.lookup_disc_id("abc")
+
+
+@respx.mock
+async def test_musicbrainz_disc_id_top_release_missing_title_raises(http_client):
+    # Covers lookup_disc_id's "top release missing title" branch.
+    respx.get("https://musicbrainz.org/ws/2/discid/abc").mock(
+        return_value=httpx.Response(200, json={"releases": [{"date": "1999"}]})
+    )
+    client = MusicBrainzClient("arm/test", http_client)
+    with pytest.raises(LookupError, match="missing title"):
+        await client.lookup_disc_id("abc")

--- a/services/backend/tests/test_metadata_clients.py
+++ b/services/backend/tests/test_metadata_clients.py
@@ -868,6 +868,16 @@ async def test_musicbrainz_get_non200_raises(http_client):
 
 
 @respx.mock
+async def test_musicbrainz_disc_id_404_not_found(http_client):
+    # A 404 on a disc lookup is an expected miss, with a disc-specific message
+    # (not the generic "status=404" that search would give).
+    respx.get("https://musicbrainz.org/ws/2/discid/abc").mock(return_value=httpx.Response(404))
+    client = MusicBrainzClient("arm/test", http_client)
+    with pytest.raises(LookupError, match="disc_id not found"):
+        await client.lookup_disc_id("abc")
+
+
+@respx.mock
 async def test_musicbrainz_disc_id_no_releases_raises(http_client):
     # Covers lookup_disc_id's "no releases" branch.
     respx.get("https://musicbrainz.org/ws/2/discid/abc").mock(return_value=httpx.Response(200, json={"releases": []}))

--- a/services/backend/tests/test_metadata_clients.py
+++ b/services/backend/tests/test_metadata_clients.py
@@ -370,3 +370,327 @@ async def test_musicbrainz_tracks_drop_entries_without_title(http_client):
         {"title": "Mystery Position"},
         {"title": "Int Position", "position": 4},
     ]
+
+
+@respx.mock
+async def test_omdb_search_candidates(http_client):
+    respx.get("https://www.omdbapi.com/").mock(
+        return_value=httpx.Response(200, json={
+            "Response": "True",
+            "Search": [
+                {"Title": "The Matrix", "Year": "1999", "imdbID": "tt0133093", "Poster": "http://x/p.jpg"},
+                {"Title": "The Matrix Reloaded", "Year": "2003", "imdbID": "tt0234215", "Poster": "N/A"},
+            ],
+        })
+    )
+    from arm_backend.metadata.omdb import OMDBClient
+    client = OMDBClient("k", http_client)
+    results = await client.search_candidates("matrix", kind="movie")
+    assert [r.title for r in results] == ["The Matrix", "The Matrix Reloaded"]
+    assert results[0].year == 1999
+    assert results[0].payload["imdbID"] == "tt0133093"
+
+
+@respx.mock
+async def test_omdb_search_no_results_returns_empty(http_client):
+    respx.get("https://www.omdbapi.com/").mock(
+        return_value=httpx.Response(200, json={"Response": "False", "Error": "Movie not found!"})
+    )
+    from arm_backend.metadata.omdb import OMDBClient
+    client = OMDBClient("k", http_client)
+    results = await client.search_candidates("zzzznope", kind="movie")
+    assert results == []
+
+
+@respx.mock
+async def test_omdb_search_auth_failure_raises(http_client):
+    respx.get("https://www.omdbapi.com/").mock(return_value=httpx.Response(401))
+    from arm_backend.metadata.omdb import OMDBClient
+    from arm_backend.metadata.base import LookupError
+    client = OMDBClient("bad", http_client)
+    with pytest.raises(LookupError):
+        await client.search_candidates("matrix", kind="movie")
+
+
+@respx.mock
+async def test_omdb_lookup_by_imdb_id(http_client):
+    respx.get("https://www.omdbapi.com/").mock(
+        return_value=httpx.Response(200, json={
+            "Response": "True", "Title": "The Matrix", "Year": "1999", "imdbID": "tt0133093",
+        })
+    )
+    from arm_backend.metadata.omdb import OMDBClient
+    client = OMDBClient("k", http_client)
+    result = await client.lookup_by_imdb_id("tt0133093")
+    assert result.title == "The Matrix"
+    assert result.year == 1999
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap tests — lookup_by_title error branches
+# ---------------------------------------------------------------------------
+
+@respx.mock
+async def test_omdb_lookup_by_title_timeout_raises(http_client):
+    from arm_backend.metadata.omdb import OMDBClient
+    from arm_backend.metadata.base import LookupTimeout
+
+    def _raise_timeout(request):
+        raise httpx.TimeoutException("timed out", request=request)
+
+    respx.get("https://www.omdbapi.com/").mock(side_effect=_raise_timeout)
+    client = OMDBClient("k", http_client)
+    with pytest.raises(LookupTimeout):
+        await client.lookup_by_title("x")
+
+
+@respx.mock
+async def test_omdb_lookup_by_title_transport_error_raises(http_client):
+    from arm_backend.metadata.omdb import OMDBClient
+
+    def _raise_transport(request):
+        raise httpx.ConnectError("conn refused", request=request)
+
+    respx.get("https://www.omdbapi.com/").mock(side_effect=_raise_transport)
+    client = OMDBClient("k", http_client)
+    with pytest.raises(LookupError):
+        await client.lookup_by_title("x")
+
+
+@respx.mock
+async def test_omdb_lookup_by_title_401_raises(http_client):
+    from arm_backend.metadata.omdb import OMDBClient
+    respx.get("https://www.omdbapi.com/").mock(return_value=httpx.Response(401))
+    client = OMDBClient("k", http_client)
+    with pytest.raises(LookupError, match="omdb auth failed"):
+        await client.lookup_by_title("x")
+
+
+@respx.mock
+async def test_omdb_lookup_by_title_5xx_raises(http_client):
+    from arm_backend.metadata.omdb import OMDBClient
+    respx.get("https://www.omdbapi.com/").mock(return_value=httpx.Response(503))
+    client = OMDBClient("k", http_client)
+    with pytest.raises(LookupError, match="5xx"):
+        await client.lookup_by_title("x")
+
+
+@respx.mock
+async def test_omdb_lookup_by_title_non200_raises(http_client):
+    from arm_backend.metadata.omdb import OMDBClient
+    respx.get("https://www.omdbapi.com/").mock(return_value=httpx.Response(404))
+    client = OMDBClient("k", http_client)
+    with pytest.raises(LookupError, match="omdb status=404"):
+        await client.lookup_by_title("x")
+
+
+@respx.mock
+async def test_omdb_lookup_by_title_missing_title_raises(http_client):
+    from arm_backend.metadata.omdb import OMDBClient
+    respx.get("https://www.omdbapi.com/").mock(
+        return_value=httpx.Response(200, json={"Response": "True", "Title": "", "Year": "2000"})
+    )
+    client = OMDBClient("k", http_client)
+    with pytest.raises(LookupError, match="missing title"):
+        await client.lookup_by_title("x")
+
+
+@respx.mock
+async def test_omdb_lookup_by_title_with_year_param(http_client):
+    """Exercises the `if year is not None: params['y'] = year` branch."""
+    from arm_backend.metadata.omdb import OMDBClient
+    respx.get("https://www.omdbapi.com/").mock(
+        return_value=httpx.Response(200, json={"Response": "True", "Title": "Blade Runner", "Year": "1982"})
+    )
+    client = OMDBClient("k", http_client)
+    result = await client.lookup_by_title("Blade Runner", year=1982)
+    assert result.year == 1982
+
+
+@respx.mock
+async def test_omdb_lookup_by_title_non_digit_year(http_client):
+    """Year field that can't be parsed as int yields year=None."""
+    from arm_backend.metadata.omdb import OMDBClient
+    respx.get("https://www.omdbapi.com/").mock(
+        return_value=httpx.Response(200, json={"Response": "True", "Title": "Old Film", "Year": "N/A"})
+    )
+    client = OMDBClient("k", http_client)
+    result = await client.lookup_by_title("Old Film")
+    assert result.year is None
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap tests — search_candidates error branches
+# ---------------------------------------------------------------------------
+
+@respx.mock
+async def test_omdb_search_candidates_timeout_raises(http_client):
+    from arm_backend.metadata.omdb import OMDBClient
+    from arm_backend.metadata.base import LookupTimeout
+
+    def _raise_timeout(request):
+        raise httpx.TimeoutException("timed out", request=request)
+
+    respx.get("https://www.omdbapi.com/").mock(side_effect=_raise_timeout)
+    client = OMDBClient("k", http_client)
+    with pytest.raises(LookupTimeout):
+        await client.search_candidates("x")
+
+
+@respx.mock
+async def test_omdb_search_candidates_transport_error_raises(http_client):
+    from arm_backend.metadata.omdb import OMDBClient
+
+    def _raise_transport(request):
+        raise httpx.ConnectError("conn refused", request=request)
+
+    respx.get("https://www.omdbapi.com/").mock(side_effect=_raise_transport)
+    client = OMDBClient("k", http_client)
+    with pytest.raises(LookupError):
+        await client.search_candidates("x")
+
+
+@respx.mock
+async def test_omdb_search_candidates_5xx_raises(http_client):
+    from arm_backend.metadata.omdb import OMDBClient
+    respx.get("https://www.omdbapi.com/").mock(return_value=httpx.Response(500))
+    client = OMDBClient("k", http_client)
+    with pytest.raises(LookupError, match="5xx"):
+        await client.search_candidates("x")
+
+
+@respx.mock
+async def test_omdb_search_candidates_non200_raises(http_client):
+    from arm_backend.metadata.omdb import OMDBClient
+    respx.get("https://www.omdbapi.com/").mock(return_value=httpx.Response(404))
+    client = OMDBClient("k", http_client)
+    with pytest.raises(LookupError, match="omdb status=404"):
+        await client.search_candidates("x")
+
+
+@respx.mock
+async def test_omdb_search_candidates_skips_items_without_title(http_client):
+    """Items in Search[] that have no Title are silently skipped."""
+    from arm_backend.metadata.omdb import OMDBClient
+    respx.get("https://www.omdbapi.com/").mock(
+        return_value=httpx.Response(200, json={
+            "Response": "True",
+            "Search": [
+                {"Title": "", "Year": "2000", "imdbID": "tt0000001"},
+                {"Year": "2001", "imdbID": "tt0000002"},  # missing Title key
+                {"Title": "Real Movie", "Year": "2002", "imdbID": "tt0000003"},
+            ],
+        })
+    )
+    client = OMDBClient("k", http_client)
+    results = await client.search_candidates("real", kind="movie")
+    assert len(results) == 1
+    assert results[0].title == "Real Movie"
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap tests — lookup_by_imdb_id error branches
+# ---------------------------------------------------------------------------
+
+@respx.mock
+async def test_omdb_lookup_by_imdb_id_timeout_raises(http_client):
+    from arm_backend.metadata.omdb import OMDBClient
+    from arm_backend.metadata.base import LookupTimeout
+
+    def _raise_timeout(request):
+        raise httpx.TimeoutException("timed out", request=request)
+
+    respx.get("https://www.omdbapi.com/").mock(side_effect=_raise_timeout)
+    client = OMDBClient("k", http_client)
+    with pytest.raises(LookupTimeout):
+        await client.lookup_by_imdb_id("tt0133093")
+
+
+@respx.mock
+async def test_omdb_lookup_by_imdb_id_transport_error_raises(http_client):
+    from arm_backend.metadata.omdb import OMDBClient
+
+    def _raise_transport(request):
+        raise httpx.ConnectError("conn refused", request=request)
+
+    respx.get("https://www.omdbapi.com/").mock(side_effect=_raise_transport)
+    client = OMDBClient("k", http_client)
+    with pytest.raises(LookupError):
+        await client.lookup_by_imdb_id("tt0133093")
+
+
+@respx.mock
+async def test_omdb_lookup_by_imdb_id_401_raises(http_client):
+    from arm_backend.metadata.omdb import OMDBClient
+    respx.get("https://www.omdbapi.com/").mock(return_value=httpx.Response(401))
+    client = OMDBClient("k", http_client)
+    with pytest.raises(LookupError, match="omdb auth failed"):
+        await client.lookup_by_imdb_id("tt0133093")
+
+
+@respx.mock
+async def test_omdb_lookup_by_imdb_id_5xx_raises(http_client):
+    from arm_backend.metadata.omdb import OMDBClient
+    respx.get("https://www.omdbapi.com/").mock(return_value=httpx.Response(503))
+    client = OMDBClient("k", http_client)
+    with pytest.raises(LookupError, match="5xx"):
+        await client.lookup_by_imdb_id("tt0133093")
+
+
+@respx.mock
+async def test_omdb_lookup_by_imdb_id_non200_raises(http_client):
+    from arm_backend.metadata.omdb import OMDBClient
+    respx.get("https://www.omdbapi.com/").mock(return_value=httpx.Response(404))
+    client = OMDBClient("k", http_client)
+    with pytest.raises(LookupError, match="omdb status=404"):
+        await client.lookup_by_imdb_id("tt0133093")
+
+
+@respx.mock
+async def test_omdb_lookup_by_imdb_id_miss_raises(http_client):
+    from arm_backend.metadata.omdb import OMDBClient
+    respx.get("https://www.omdbapi.com/").mock(
+        return_value=httpx.Response(200, json={"Response": "False", "Error": "Incorrect IMDb ID."})
+    )
+    client = OMDBClient("k", http_client)
+    with pytest.raises(LookupError, match="omdb miss"):
+        await client.lookup_by_imdb_id("tt9999999")
+
+
+@respx.mock
+async def test_omdb_lookup_by_imdb_id_missing_title_raises(http_client):
+    from arm_backend.metadata.omdb import OMDBClient
+    respx.get("https://www.omdbapi.com/").mock(
+        return_value=httpx.Response(200, json={"Response": "True", "Title": "", "Year": "2000"})
+    )
+    client = OMDBClient("k", http_client)
+    with pytest.raises(LookupError, match="missing title"):
+        await client.lookup_by_imdb_id("tt0133093")
+
+
+@respx.mock
+async def test_omdb_lookup_by_imdb_id_tv_series_kind(http_client):
+    """When OMDB returns Type=series, kind is set to 'tv'."""
+    from arm_backend.metadata.omdb import OMDBClient
+    respx.get("https://www.omdbapi.com/").mock(
+        return_value=httpx.Response(200, json={
+            "Response": "True", "Title": "Breaking Bad", "Year": "2008", "Type": "series",
+        })
+    )
+    client = OMDBClient("k", http_client)
+    result = await client.lookup_by_imdb_id("tt0903747")
+    assert result.kind == "tv"
+
+
+@respx.mock
+async def test_omdb_lookup_by_imdb_id_non_digit_year(http_client):
+    """Year field that can't be parsed yields year=None."""
+    from arm_backend.metadata.omdb import OMDBClient
+    respx.get("https://www.omdbapi.com/").mock(
+        return_value=httpx.Response(200, json={
+            "Response": "True", "Title": "Some Show", "Year": "N/A", "Type": "movie",
+        })
+    )
+    client = OMDBClient("k", http_client)
+    result = await client.lookup_by_imdb_id("tt0000001")
+    assert result.year is None

--- a/services/backend/tests/test_metadata_clients.py
+++ b/services/backend/tests/test_metadata_clients.py
@@ -575,3 +575,71 @@ async def test_omdb_lookup_by_imdb_id_tv_series_kind(http_client):
     client = OMDBClient("k", http_client)
     result = await client.lookup_by_imdb_id("tt0903747")
     assert result.kind == "tv"
+
+
+# ---------------------------------------------------------------------------
+# TMDB multi-result candidate search
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_tmdb_search_movie_candidates(http_client):
+    respx.get("https://api.themoviedb.org/3/search/movie").mock(
+        return_value=httpx.Response(200, json={"results": [
+            {"title": "The Matrix", "release_date": "1999-03-31", "id": 603, "poster_path": "/a.jpg"},
+            {"title": "The Matrix Reloaded", "release_date": "2003-05-15", "id": 604, "poster_path": "/b.jpg"},
+        ]})
+    )
+    client = TMDBClient("k", http_client)
+    results = await client.search_movie_candidates("matrix")
+    assert [r.title for r in results] == ["The Matrix", "The Matrix Reloaded"]
+    assert results[0].year == 1999
+    assert results[0].payload["poster_path"] == "/a.jpg"
+
+
+@respx.mock
+async def test_tmdb_search_tv_candidates(http_client):
+    respx.get("https://api.themoviedb.org/3/search/tv").mock(
+        return_value=httpx.Response(200, json={"results": [
+            {"name": "Battlestar Galactica", "first_air_date": "2004-10-18", "id": 1972},
+        ]})
+    )
+    client = TMDBClient("k", http_client)
+    results = await client.search_tv_candidates("galactica")
+    assert results[0].title == "Battlestar Galactica"
+    assert results[0].year == 2004
+    assert results[0].kind == "tv"
+
+
+@respx.mock
+async def test_tmdb_search_empty_results(http_client):
+    respx.get("https://api.themoviedb.org/3/search/movie").mock(
+        return_value=httpx.Response(200, json={"results": []})
+    )
+    client = TMDBClient("k", http_client)
+    assert await client.search_movie_candidates("zzz") == []
+
+
+@respx.mock
+async def test_tmdb_search_auth_failure_raises(http_client):
+    respx.get("https://api.themoviedb.org/3/search/movie").mock(return_value=httpx.Response(401))
+    client = TMDBClient("bad", http_client)
+    with pytest.raises(LookupError):
+        await client.search_movie_candidates("matrix")
+
+
+@respx.mock
+async def test_tmdb_search_candidates_skips_items_without_title(http_client):
+    """Items with no usable title are silently skipped; tv path + original_name fallback exercised."""
+    respx.get("https://api.themoviedb.org/3/search/tv").mock(
+        return_value=httpx.Response(200, json={"results": [
+            {"name": "", "first_air_date": "2000-01-01", "id": 1},          # empty name — skip
+            {"first_air_date": "2001-01-01", "id": 2},                       # missing name key — skip
+            {"original_name": "Fallback Show", "first_air_date": "2002-06-01", "id": 3},  # original_name fallback
+        ]})
+    )
+    client = TMDBClient("k", http_client)
+    results = await client.search_tv_candidates("x")
+    assert len(results) == 1
+    assert results[0].title == "Fallback Show"
+    assert results[0].year == 2002

--- a/services/backend/tests/test_metadata_search_router.py
+++ b/services/backend/tests/test_metadata_search_router.py
@@ -1,0 +1,342 @@
+"""GET /api/metadata/search, /lookup, /music/search."""
+
+from __future__ import annotations
+
+import os
+import secrets
+import unittest.mock as mock
+
+os.environ.setdefault("DATABASE_URL", "postgresql://x:x@localhost/x")
+os.environ.setdefault("ARM_SERVICE_TOKEN", "tok-service")
+
+import httpx  # noqa: E402
+import pytest  # noqa: E402
+import respx  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from arm_backend.db import get_session  # noqa: E402
+from arm_backend.jwt_utils import issue_access_token  # noqa: E402
+from arm_backend.metadata import musicbrainz as mb_mod  # noqa: E402
+from arm_backend.metadata import omdb as omdb_mod  # noqa: E402
+from arm_backend.metadata.base import LookupError as MetaLookupError  # noqa: E402
+from arm_backend.routers import metadata as metadata_router  # noqa: E402
+from arm_common import Config, User  # noqa: E402
+
+from tests._fakes import FakeSession  # noqa: E402
+
+
+@pytest.fixture
+def signing_key() -> bytes:
+    return secrets.token_bytes(32)
+
+
+def _seed(db: FakeSession, **keys: str | None) -> None:
+    db.rows["users"] = [User(id="usr_admin", username="admin", password_hash="x", password_must_change=False)]
+    db.rows["config"] = [Config(id=1, musicbrainz_user_agent="arm/test", **keys)]
+
+
+def _make_app(signing_key: bytes, db: FakeSession) -> tuple[FastAPI, str]:
+    app = FastAPI()
+    app.state.signing_key = signing_key
+    app.state.http = httpx.AsyncClient(timeout=5.0)
+    app.include_router(metadata_router.router)
+
+    async def _override() -> FakeSession:
+        return db
+
+    app.dependency_overrides[get_session] = _override
+    token, _ = issue_access_token("usr_admin", "admin", signing_key)
+    return app, token
+
+
+def _auth(t: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {t}"}
+
+
+@respx.mock
+def test_search_tmdb_returns_candidates(signing_key: bytes) -> None:
+    respx.get("https://api.themoviedb.org/3/search/movie").mock(
+        return_value=httpx.Response(200, json={"results": [
+            {"title": "The Matrix", "release_date": "1999-03-31", "id": 603, "poster_path": "/a.jpg"},
+        ]})
+    )
+    db = FakeSession()
+    _seed(db, tmdb_api_key="k")
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/search", params={"title": "matrix", "type": "movie"}, headers=_auth(token))
+    assert r.status_code == 200, r.text
+    cands = r.json()["candidates"]
+    assert cands[0]["title"] == "The Matrix"
+    assert cands[0]["poster_url"]
+
+
+def test_search_no_key_returns_400(signing_key: bytes) -> None:
+    db = FakeSession()
+    _seed(db, tmdb_api_key=None)
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/search", params={"title": "x", "type": "movie"}, headers=_auth(token))
+    assert r.status_code == 400
+
+
+@respx.mock
+def test_search_provider_error_returns_200_empty(signing_key: bytes) -> None:
+    respx.get("https://api.themoviedb.org/3/search/movie").mock(side_effect=httpx.ConnectError("down"))
+    db = FakeSession()
+    _seed(db, tmdb_api_key="k")
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/search", params={"title": "x", "type": "movie"}, headers=_auth(token))
+    assert r.status_code == 200, r.text
+    assert r.json()["candidates"] == []
+    assert r.json()["detail"]
+
+
+def test_search_unknown_type_returns_422(signing_key: bytes) -> None:
+    db = FakeSession()
+    _seed(db, tmdb_api_key="k")
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/search", params={"title": "x", "type": "bogus"}, headers=_auth(token))
+    assert r.status_code == 422
+
+
+@respx.mock
+def test_lookup_by_imdb_id(signing_key: bytes) -> None:
+    respx.get("https://www.omdbapi.com/").mock(
+        return_value=httpx.Response(200, json={"Response": "True", "Title": "The Matrix", "Year": "1999"})
+    )
+    db = FakeSession()
+    _seed(db, omdb_api_key="k")
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/lookup", params={"imdb_id": "tt0133093"}, headers=_auth(token))
+    assert r.status_code == 200, r.text
+    assert r.json()["candidates"][0]["title"] == "The Matrix"
+
+
+def test_lookup_neither_param_returns_422(signing_key: bytes) -> None:
+    db = FakeSession()
+    _seed(db, omdb_api_key="k")
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/lookup", headers=_auth(token))
+    assert r.status_code == 422
+
+
+def test_lookup_both_params_returns_422(signing_key: bytes) -> None:
+    db = FakeSession()
+    _seed(db, omdb_api_key="k")
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/lookup", params={"imdb_id": "tt1", "crc64": "abc"}, headers=_auth(token))
+    assert r.status_code == 422
+
+
+@respx.mock
+def test_music_search(signing_key: bytes) -> None:
+    respx.get("https://musicbrainz.org/ws/2/release").mock(
+        return_value=httpx.Response(200, json={"releases": [
+            {"title": "Wish You Were Here", "date": "1975-09-12", "id": "mb-2"},
+        ]})
+    )
+    db = FakeSession()
+    _seed(db)
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/music/search", params={"query": "wish you were here"}, headers=_auth(token))
+    assert r.status_code == 200, r.text
+    assert r.json()["candidates"][0]["title"] == "Wish You Were Here"
+
+
+def test_search_unauthenticated_401(signing_key: bytes) -> None:
+    db = FakeSession()
+    _seed(db, tmdb_api_key="k")
+    app, _ = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/search", params={"title": "x", "type": "movie"})
+    assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap-fillers: crc64 lookup, omdb-provider search, no-omdb-key 400,
+# music provider error, search tv path
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_lookup_by_crc64(signing_key: bytes) -> None:
+    """ArmServerClient.lookup_by_crc64 path."""
+    respx.get("https://1337server.pythonanywhere.com/api/v1/").mock(
+        return_value=httpx.Response(200, json={
+            "success": True,
+            "results": {"0": {"title": "Frozen", "year": 2013, "video_type": "movie"}},
+        })
+    )
+    db = FakeSession()
+    _seed(db)
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/lookup", params={"crc64": "deadbeef12345678"}, headers=_auth(token))
+    assert r.status_code == 200, r.text
+    assert r.json()["candidates"][0]["title"] == "Frozen"
+
+
+@respx.mock
+def test_search_omdb_provider_returns_candidates(signing_key: bytes) -> None:
+    """provider=omdb path in search_metadata."""
+    respx.get("https://www.omdbapi.com/").mock(
+        return_value=httpx.Response(200, json={
+            "Response": "True",
+            "Search": [{"Title": "Blade Runner", "Year": "1982", "imdbID": "tt0083658", "Type": "movie"}],
+        })
+    )
+    db = FakeSession()
+    _seed(db, omdb_api_key="k")
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get(
+            "/api/metadata/search",
+            params={"title": "blade runner", "type": "movie", "provider": "omdb"},
+            headers=_auth(token),
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["candidates"][0]["title"] == "Blade Runner"
+
+
+def test_lookup_imdb_no_omdb_key_returns_400(signing_key: bytes) -> None:
+    """imdb_id path with no omdb key → 400."""
+    db = FakeSession()
+    _seed(db, omdb_api_key=None)
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/lookup", params={"imdb_id": "tt0133093"}, headers=_auth(token))
+    assert r.status_code == 400
+
+
+@respx.mock
+def test_music_search_provider_error_returns_200_empty(signing_key: bytes) -> None:
+    """MusicBrainz transport error → 200 + empty candidates + detail."""
+    respx.get("https://musicbrainz.org/ws/2/release").mock(side_effect=httpx.ConnectError("down"))
+    db = FakeSession()
+    _seed(db)
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/music/search", params={"query": "something"}, headers=_auth(token))
+    assert r.status_code == 200, r.text
+    assert r.json()["candidates"] == []
+    assert r.json()["detail"]
+
+
+@respx.mock
+def test_search_tmdb_tv_candidates(signing_key: bytes) -> None:
+    """type=tv hits search_tv_candidates."""
+    respx.get("https://api.themoviedb.org/3/search/tv").mock(
+        return_value=httpx.Response(200, json={"results": [
+            {"name": "Breaking Bad", "first_air_date": "2008-01-20", "id": 1396},
+        ]})
+    )
+    db = FakeSession()
+    _seed(db, tmdb_api_key="k")
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/search", params={"title": "breaking bad", "type": "tv"}, headers=_auth(token))
+    assert r.status_code == 200, r.text
+    assert r.json()["candidates"][0]["title"] == "Breaking Bad"
+
+
+def test_search_config_not_initialised_returns_400(signing_key: bytes) -> None:
+    """No Config row → search_metadata raises 400."""
+    db = FakeSession()
+    db.rows["users"] = [User(id="usr_admin", username="admin", password_hash="x", password_must_change=False)]
+    # no config row
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/search", params={"title": "x", "type": "movie"}, headers=_auth(token))
+    assert r.status_code == 400
+    assert "config" in r.json()["detail"].lower()
+
+
+def test_lookup_config_not_initialised_returns_400(signing_key: bytes) -> None:
+    """No Config row → lookup_metadata raises 400."""
+    db = FakeSession()
+    db.rows["users"] = [User(id="usr_admin", username="admin", password_hash="x", password_must_change=False)]
+    # no config row
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/lookup", params={"imdb_id": "tt1"}, headers=_auth(token))
+    assert r.status_code == 400
+    assert "config" in r.json()["detail"].lower()
+
+
+@respx.mock
+def test_search_httpx_error_returns_200_empty(signing_key: bytes) -> None:
+    """httpx.HTTPError escaping the OMDB client → 200 + empty (safety net branch)."""
+    db = FakeSession()
+    _seed(db, omdb_api_key="k")
+    app, token = _make_app(signing_key, db)
+    with mock.patch.object(omdb_mod.OMDBClient, "search_candidates", side_effect=httpx.RemoteProtocolError("bad")):
+        with TestClient(app) as c:
+            r = c.get(
+                "/api/metadata/search",
+                params={"title": "x", "type": "movie", "provider": "omdb"},
+                headers=_auth(token),
+            )
+    assert r.status_code == 200, r.text
+    assert r.json()["candidates"] == []
+    assert r.json()["detail"]
+
+
+@respx.mock
+def test_lookup_httpx_error_returns_200_empty(signing_key: bytes) -> None:
+    """httpx.HTTPError in lookup_metadata safety net."""
+    db = FakeSession()
+    _seed(db, omdb_api_key="k")
+    app, token = _make_app(signing_key, db)
+    with mock.patch.object(omdb_mod.OMDBClient, "lookup_by_imdb_id", side_effect=httpx.RemoteProtocolError("bad")):
+        with TestClient(app) as c:
+            r = c.get("/api/metadata/lookup", params={"imdb_id": "tt1"}, headers=_auth(token))
+    assert r.status_code == 200, r.text
+    assert r.json()["candidates"] == []
+    assert r.json()["detail"]
+
+
+def test_music_search_lookup_error_returns_200_empty(signing_key: bytes) -> None:
+    """MetaLookupError in search_music → 200 + empty + detail."""
+    db = FakeSession()
+    _seed(db)
+    app, token = _make_app(signing_key, db)
+    with mock.patch.object(mb_mod.MusicBrainzClient, "search_releases", side_effect=MetaLookupError("mb down")):
+        with TestClient(app) as c:
+            r = c.get("/api/metadata/music/search", params={"query": "x"}, headers=_auth(token))
+    assert r.status_code == 200, r.text
+    assert r.json()["candidates"] == []
+    assert "mb down" in r.json()["detail"]
+
+
+def test_lookup_lookup_error_returns_200_empty(signing_key: bytes) -> None:
+    """MetaLookupError in lookup_metadata → 200 + empty + detail."""
+    db = FakeSession()
+    _seed(db, omdb_api_key="k")
+    app, token = _make_app(signing_key, db)
+    with mock.patch.object(omdb_mod.OMDBClient, "lookup_by_imdb_id", side_effect=MetaLookupError("omdb miss")):
+        with TestClient(app) as c:
+            r = c.get("/api/metadata/lookup", params={"imdb_id": "tt1"}, headers=_auth(token))
+    assert r.status_code == 200, r.text
+    assert r.json()["candidates"] == []
+    assert "omdb miss" in r.json()["detail"]
+
+
+def test_music_search_httpx_error_returns_200_empty(signing_key: bytes) -> None:
+    """httpx.HTTPError in search_music safety net → 200 + empty + detail."""
+    db = FakeSession()
+    _seed(db)
+    app, token = _make_app(signing_key, db)
+    with mock.patch.object(mb_mod.MusicBrainzClient, "search_releases", side_effect=httpx.RemoteProtocolError("bad")):
+        with TestClient(app) as c:
+            r = c.get("/api/metadata/music/search", params={"query": "x"}, headers=_auth(token))
+    assert r.status_code == 200, r.text
+    assert r.json()["candidates"] == []
+    assert r.json()["detail"]

--- a/services/backend/tests/test_metadata_search_router.py
+++ b/services/backend/tests/test_metadata_search_router.py
@@ -57,9 +57,14 @@ def _auth(t: str) -> dict[str, str]:
 @respx.mock
 def test_search_tmdb_returns_candidates(signing_key: bytes) -> None:
     respx.get("https://api.themoviedb.org/3/search/movie").mock(
-        return_value=httpx.Response(200, json={"results": [
-            {"title": "The Matrix", "release_date": "1999-03-31", "id": 603, "poster_path": "/a.jpg"},
-        ]})
+        return_value=httpx.Response(
+            200,
+            json={
+                "results": [
+                    {"title": "The Matrix", "release_date": "1999-03-31", "id": 603, "poster_path": "/a.jpg"},
+                ]
+            },
+        )
     )
     db = FakeSession()
     _seed(db, tmdb_api_key="k")
@@ -138,9 +143,14 @@ def test_lookup_both_params_returns_422(signing_key: bytes) -> None:
 @respx.mock
 def test_music_search(signing_key: bytes) -> None:
     respx.get("https://musicbrainz.org/ws/2/release").mock(
-        return_value=httpx.Response(200, json={"releases": [
-            {"title": "Wish You Were Here", "date": "1975-09-12", "id": "mb-2"},
-        ]})
+        return_value=httpx.Response(
+            200,
+            json={
+                "releases": [
+                    {"title": "Wish You Were Here", "date": "1975-09-12", "id": "mb-2"},
+                ]
+            },
+        )
     )
     db = FakeSession()
     _seed(db)
@@ -170,10 +180,13 @@ def test_search_unauthenticated_401(signing_key: bytes) -> None:
 def test_lookup_by_crc64(signing_key: bytes) -> None:
     """ArmServerClient.lookup_by_crc64 path."""
     respx.get("https://1337server.pythonanywhere.com/api/v1/").mock(
-        return_value=httpx.Response(200, json={
-            "success": True,
-            "results": {"0": {"title": "Frozen", "year": 2013, "video_type": "movie"}},
-        })
+        return_value=httpx.Response(
+            200,
+            json={
+                "success": True,
+                "results": {"0": {"title": "Frozen", "year": 2013, "video_type": "movie"}},
+            },
+        )
     )
     db = FakeSession()
     _seed(db)
@@ -188,10 +201,13 @@ def test_lookup_by_crc64(signing_key: bytes) -> None:
 def test_search_omdb_provider_returns_candidates(signing_key: bytes) -> None:
     """provider=omdb path in search_metadata."""
     respx.get("https://www.omdbapi.com/").mock(
-        return_value=httpx.Response(200, json={
-            "Response": "True",
-            "Search": [{"Title": "Blade Runner", "Year": "1982", "imdbID": "tt0083658", "Type": "movie"}],
-        })
+        return_value=httpx.Response(
+            200,
+            json={
+                "Response": "True",
+                "Search": [{"Title": "Blade Runner", "Year": "1982", "imdbID": "tt0083658", "Type": "movie"}],
+            },
+        )
     )
     db = FakeSession()
     _seed(db, omdb_api_key="k")
@@ -234,9 +250,14 @@ def test_music_search_provider_error_returns_200_empty(signing_key: bytes) -> No
 def test_search_tmdb_tv_candidates(signing_key: bytes) -> None:
     """type=tv hits search_tv_candidates."""
     respx.get("https://api.themoviedb.org/3/search/tv").mock(
-        return_value=httpx.Response(200, json={"results": [
-            {"name": "Breaking Bad", "first_air_date": "2008-01-20", "id": 1396},
-        ]})
+        return_value=httpx.Response(
+            200,
+            json={
+                "results": [
+                    {"name": "Breaking Bad", "first_air_date": "2008-01-20", "id": 1396},
+                ]
+            },
+        )
     )
     db = FakeSession()
     _seed(db, tmdb_api_key="k")

--- a/services/backend/tests/test_metadata_search_router.py
+++ b/services/backend/tests/test_metadata_search_router.py
@@ -389,10 +389,14 @@ def test_music_release_detail_ok(signing_key: bytes) -> None:
         r = c.get("/api/metadata/music/mbid-1", headers=_auth(token))
     assert r.status_code == 200, r.text
     body = r.json()
+    assert body["release_id"] == "mbid-1"
     assert body["title"] == "The Dark Side of the Moon"
     assert body["year"] == 1973
-    assert body["kind"] == "music"
-    assert body["provider_id"] == "mbid-1"
+    assert body["artist"] == "Pink Floyd"
+    # M5 fix: the detail view must carry the track listing get_release fetched.
+    assert len(body["tracks"]) > 0
+    assert body["tracks"][0]["title"] == "Speak to Me"
+    assert body["tracks"][0]["position"] == 1
 
 
 @respx.mock

--- a/services/backend/tests/test_metadata_search_router.py
+++ b/services/backend/tests/test_metadata_search_router.py
@@ -361,3 +361,59 @@ def test_music_search_httpx_error_returns_200_empty(signing_key: bytes) -> None:
     assert r.status_code == 200, r.text
     assert r.json()["candidates"] == []
     assert r.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/metadata/music/{release_id} — release detail by MBID
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_music_release_detail_ok(signing_key: bytes) -> None:
+    respx.get("https://musicbrainz.org/ws/2/release/mbid-1").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "mbid-1",
+                "title": "The Dark Side of the Moon",
+                "date": "1973-03-01",
+                "artist-credit": [{"name": "Pink Floyd"}],
+                "media": [{"tracks": [{"position": "1", "title": "Speak to Me"}]}],
+            },
+        )
+    )
+    db = FakeSession()
+    _seed(db)
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/music/mbid-1", headers=_auth(token))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["title"] == "The Dark Side of the Moon"
+    assert body["year"] == 1973
+    assert body["kind"] == "music"
+    assert body["provider_id"] == "mbid-1"
+
+
+@respx.mock
+def test_music_release_detail_404(signing_key: bytes) -> None:
+    """Unknown MBID → upstream 404 → 404."""
+    respx.get("https://musicbrainz.org/ws/2/release/missing").mock(return_value=httpx.Response(404))
+    db = FakeSession()
+    _seed(db)
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/music/missing", headers=_auth(token))
+    assert r.status_code == 404, r.text
+
+
+@respx.mock
+def test_music_release_detail_unavailable_502(signing_key: bytes) -> None:
+    """Transport failure (collapsed into LookupError by _get) → 502, not 404."""
+    respx.get("https://musicbrainz.org/ws/2/release/mbid-1").mock(side_effect=httpx.ConnectError("boom"))
+    db = FakeSession()
+    _seed(db)
+    app, token = _make_app(signing_key, db)
+    with TestClient(app) as c:
+        r = c.get("/api/metadata/music/mbid-1", headers=_auth(token))
+    assert r.status_code == 502, r.text

--- a/services/ui/openapi.snapshot.json
+++ b/services/ui/openapi.snapshot.json
@@ -3407,6 +3407,289 @@
         }
       }
     },
+    "/api/metadata/search": {
+      "get": {
+        "tags": [
+          "metadata"
+        ],
+        "summary": "Search Metadata",
+        "operationId": "search_metadata_api_metadata_search_get",
+        "parameters": [
+          {
+            "name": "title",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Title"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "movie",
+                "tv"
+              ],
+              "type": "string",
+              "default": "movie",
+              "title": "Type"
+            }
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "tmdb",
+                "omdb"
+              ],
+              "type": "string",
+              "default": "tmdb",
+              "title": "Provider"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataSearchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/metadata/lookup": {
+      "get": {
+        "tags": [
+          "metadata"
+        ],
+        "summary": "Lookup Metadata",
+        "operationId": "lookup_metadata_api_metadata_lookup_get",
+        "parameters": [
+          {
+            "name": "imdb_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Imdb Id"
+            }
+          },
+          {
+            "name": "crc64",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Crc64"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataSearchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/metadata/music/search": {
+      "get": {
+        "tags": [
+          "metadata"
+        ],
+        "summary": "Search Music",
+        "operationId": "search_music_api_metadata_music_search_get",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Query"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataSearchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/metadata/music/{release_id}": {
+      "get": {
+        "tags": [
+          "metadata"
+        ],
+        "summary": "Music Release Detail",
+        "operationId": "music_release_detail_api_metadata_music__release_id__get",
+        "parameters": [
+          {
+            "name": "release_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Release Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataReleaseDetail"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/naming/variables": {
       "get": {
         "tags": [
@@ -5040,6 +5323,57 @@
         ],
         "title": "MediaType"
       },
+      "MetadataCandidate": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Year"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "poster_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Poster Url"
+          },
+          "provider_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title",
+          "kind"
+        ],
+        "title": "MetadataCandidate"
+      },
       "MetadataKeyTestResponse": {
         "properties": {
           "provider": {
@@ -5074,6 +5408,115 @@
           "valid"
         ],
         "title": "MetadataKeyTestResponse"
+      },
+      "MetadataReleaseDetail": {
+        "properties": {
+          "release_id": {
+            "type": "string",
+            "title": "Release Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "artist": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Artist"
+          },
+          "year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Year"
+          },
+          "poster_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Poster Url"
+          },
+          "tracks": {
+            "items": {
+              "$ref": "#/components/schemas/MetadataReleaseTrack"
+            },
+            "type": "array",
+            "title": "Tracks"
+          }
+        },
+        "type": "object",
+        "required": [
+          "release_id",
+          "title"
+        ],
+        "title": "MetadataReleaseDetail"
+      },
+      "MetadataReleaseTrack": {
+        "properties": {
+          "position": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Position"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "MetadataReleaseTrack"
+      },
+      "MetadataSearchResponse": {
+        "properties": {
+          "candidates": {
+            "items": {
+              "$ref": "#/components/schemas/MetadataCandidate"
+            },
+            "type": "array",
+            "title": "Candidates"
+          },
+          "detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "candidates"
+        ],
+        "title": "MetadataSearchResponse"
       },
       "NamingPreviewItem": {
         "properties": {


### PR DESCRIPTION
## Stacked PR — Tier 2.1 of the neu-port stack (split from the former Tier-2 PR)

> **Stack (merge bottom-up):**
> 1. #6 — Tier-1 (`feat/neu-ports` → `main`)
> 2. #51 — Tier-2.1 metadata (`feat/tier2.1-metadata` → `feat/neu-ports`)
> 3. #52 — Tier-2.2 system (`feat/tier2.2-system` → `feat/tier2.1-metadata`)
> 4. #7 — Tier-2.3 pause gate (`feat/tier2-ports` → `feat/tier2.2-system`)
> 5. #8 — Tier-3.1 bus + apprise channels (`feat/notification-channels` → `feat/tier2-ports`)
> 6. #53 — Tier-3.2 in-app inbox (`feat/tier3.2-inbox` → `feat/notification-channels`)
> 7. #9 — Tier-4 quick-wins (`feat/tier4-quickwins` → `feat/tier3.2-inbox`)
> 8. #10 — Tier-5 metadata imdb-id round-trip (`feat/metadata-imdb-identify` → `feat/tier4-quickwins`)

## Features in this PR

- **Metadata search + lookup** — interactive `GET /api/metadata/search`, IMDb lookup, MusicBrainz release search, and CRC64 disc-id lookup over the existing OMDb/TMDb/MusicBrainz clients. Search/lookup only — not TVDB episode matching.
- **MusicBrainz release detail** — `GET /api/metadata/music/{release_id}` returns a `MetadataReleaseDetail` (artist + `tracks[]`) by MBID over the existing client; 404 for unknown id, 502 for upstream outage.

## Scope / non-goals

Feature *logic* ported from neu; *mechanism* redesigned for v3 (stateless ripper, backend-owns-state). No UI work — backend endpoints only.

## Testing

- `uv run pytest` — 812 backend tests green on the branch (zero-infra: in-memory fake session, no Docker/Postgres/network).
- Covers each endpoint incl. auth (401), validation (422), metadata client transport-error paths, and the music-detail 404/502 split.
- OpenAPI snapshot regenerated for exactly this surface (CI `openapi-drift` gate).

## Notes for review

- Route ordering: `/music/search` is declared before `/music/{release_id}` (no shadowing).
- Split provenance: 15 commits, unchanged from the reviewed Tier-2 line; the combined 2.1+2.2+2.3 tree is byte-identical to the pre-split `feat/tier2-ports` tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)