### PR TITLE
fix: entrypoint derives render-node gid from the device (QSV/VAAPI)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,9 +60,10 @@ ARM_DOCKER_NETWORK=armv3_default
 #   ARM_GPUS=[{"vendor":"qsv","device_path":"/dev/dri/renderD128","encoder_kinds":["h264","h265"]}]
 ARM_GPUS=[]
 #
-# GID of the host's /dev/dri render-node group (also detected by the installer).
-# The dispatcher adds it to VAAPI/QSV transcoders so the PUID-dropped process can
-# open the render node (root:render 0660). Empty => not added (CPU / NVENC-only).
+# OPTIONAL override for the render-node group gid (QSV/VAAPI transcode).
+# Leave empty: the transcode container derives the gid from the mounted
+# /dev/dri render node itself, correct on local and remote hosts. Set only
+# to force a specific gid.
 ARM_RENDER_GID=
 #
 # NVIDIA hosts also need nvidia-container-toolkit so the docker daemon can pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,16 @@ jobs:
           fi
           shellcheck "${files[@]}"
 
+  test-shell:
+    name: test (shell — plain-bash suites)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      # Zero-infra unit test that sources docker-entrypoint.sh via its
+      # ARM_ENTRYPOINT_SOURCE_ONLY seam — no docker, no root, <1s.
+      - name: Entrypoint render-access suite
+        run: bash services/_common/test-entrypoint-render.sh
+
   test-python:
     name: test (python — pytest)
     runs-on: ubuntu-latest

--- a/services/_common/docker-entrypoint.sh
+++ b/services/_common/docker-entrypoint.sh
@@ -20,14 +20,19 @@ PGID="${PGID:-1000}"
 setup_render_access() {
     local dri_dir="${ARM_RENDER_NODE_DIR:-/dev/dri}"
     if [[ -n "${RENDER_GID:-}" ]]; then
+        if [[ "${RENDER_GID}" == "0" ]]; then
+            echo "render access: refusing explicit RENDER_GID=0 — never adding arm to gid 0" >&2
+            return 0
+        fi
         _join_render_gid "${RENDER_GID}" "render-host"
         echo "render access: RENDER_GID=${RENDER_GID} (explicit)"
         return 0
     fi
-    local node gid g seen failed=0
+    local node gid g seen failed=0 found=0
     local gids=()
     for node in "${dri_dir}"/renderD*; do
         [[ -e "$node" ]] || continue
+        found=1
         if ! gid="$(stat -c '%g' "$node" 2>/dev/null)"; then
             echo "render access: FAILED — cannot stat ${node}" >&2
             failed=1
@@ -45,10 +50,15 @@ setup_render_access() {
     done
     if [[ "${#gids[@]}" -gt 0 ]]; then
         echo "render access: derived gid(s) ${gids[*]} from ${dri_dir}/renderD*"
-    elif [[ "$failed" == "0" && "${ARM_GPU_DEVICE:-}" == /dev/dri/* ]]; then
-        # The dispatcher assigned a render-node GPU but nothing is visible —
-        # HandBrake will fail encoder init; make the cause greppable here.
-        echo "render access: FAILED — ARM_GPU_DEVICE=${ARM_GPU_DEVICE} set but no ${dri_dir}/renderD* visible" >&2
+    elif [[ "${ARM_GPU_DEVICE:-}" == /dev/dri/* ]]; then
+        # The dispatcher assigned a render-node GPU but no usable gid was
+        # derived — HandBrake will fail encoder init; make the cause greppable.
+        # (Per-node stat failures already printed their own FAILED line.)
+        if [[ "$found" == "0" ]]; then
+            echo "render access: FAILED — ARM_GPU_DEVICE=${ARM_GPU_DEVICE} set but no ${dri_dir}/renderD* visible" >&2
+        elif [[ "$failed" == "0" ]]; then
+            echo "render access: FAILED — ARM_GPU_DEVICE=${ARM_GPU_DEVICE} set but no usable render gid (node group is root)" >&2
+        fi
     fi
     return 0
 }
@@ -68,8 +78,9 @@ _join_render_gid() {
 
 # Test seam: lets services/_common/test-entrypoint-render.sh source the
 # functions above without executing the entrypoint (mirrors install.sh's
-# ARM_INSTALL_SOURCE_ONLY). No-op in production.
-[[ -n "${ARM_ENTRYPOINT_SOURCE_ONLY:-}" ]] && return 0
+# ARM_INSTALL_SOURCE_ONLY). The sourced-ness check makes a leaked env var
+# harmless when the entrypoint is EXECUTED (top-level `return` would abort).
+[[ -n "${ARM_ENTRYPOINT_SOURCE_ONLY:-}" && "${BASH_SOURCE[0]}" != "$0" ]] && return 0
 
 if [[ -f /etc/ssl/arm/arm-ca.crt ]]; then
     cp /etc/ssl/arm/arm-ca.crt /usr/local/share/ca-certificates/arm-ca.crt

--- a/services/_common/docker-entrypoint.sh
+++ b/services/_common/docker-entrypoint.sh
@@ -4,6 +4,73 @@ set -euo pipefail
 PUID="${PUID:-1000}"
 PGID="${PGID:-1000}"
 
+# ---------------------------------------------------------------- functions
+
+# Grant the arm user access to /dev/dri render nodes BEFORE the gosu drop —
+# gosu resets supplementary groups, so a docker --group-add would not survive;
+# membership must be written to /etc/group here.
+#
+# Resolution order:
+#   1. Explicit RENDER_GID env (dispatcher override / legacy configs) — wins.
+#   2. Self-derive: stat every mounted renderD* node. Device nodes keep their
+#      HOST gid inside the container, so this is correct on whichever host the
+#      container actually runs (local or remote offload) with zero config.
+# No nodes and no RENDER_GID → silent no-op (backend/ripper/ui/CPU/NVENC).
+# ARM_RENDER_NODE_DIR is a test seam; production always uses /dev/dri.
+setup_render_access() {
+    local dri_dir="${ARM_RENDER_NODE_DIR:-/dev/dri}"
+    if [[ -n "${RENDER_GID:-}" ]]; then
+        _join_render_gid "${RENDER_GID}" "render-host"
+        echo "render access: RENDER_GID=${RENDER_GID} (explicit)"
+        return 0
+    fi
+    local node gid g seen failed=0
+    local gids=()
+    for node in "${dri_dir}"/renderD*; do
+        [[ -e "$node" ]] || continue
+        if ! gid="$(stat -c '%g' "$node" 2>/dev/null)"; then
+            echo "render access: FAILED — cannot stat ${node}" >&2
+            failed=1
+            continue
+        fi
+        if [[ "$gid" == "0" ]]; then
+            echo "render access: skipping ${node} (group root) — refusing to add arm to gid 0" >&2
+            continue
+        fi
+        seen=0
+        for g in "${gids[@]}"; do [[ "$g" == "$gid" ]] && seen=1; done
+        [[ "$seen" == "1" ]] && continue
+        gids+=("$gid")
+        _join_render_gid "$gid" "render-host-${gid}"
+    done
+    if [[ "${#gids[@]}" -gt 0 ]]; then
+        echo "render access: derived gid(s) ${gids[*]} from ${dri_dir}/renderD*"
+    elif [[ "$failed" == "0" && "${ARM_GPU_DEVICE:-}" == /dev/dri/* ]]; then
+        # The dispatcher assigned a render-node GPU but nothing is visible —
+        # HandBrake will fail encoder init; make the cause greppable here.
+        echo "render access: FAILED — ARM_GPU_DEVICE=${ARM_GPU_DEVICE} set but no ${dri_dir}/renderD* visible" >&2
+    fi
+    return 0
+}
+
+# _join_render_gid <gid> <fallback_name>: adopt an existing group by gid, else
+# create <fallback_name> with that gid; then append arm. Mirrors the
+# CDROM_GID / docker.sock adopt-by-gid handling below.
+_join_render_gid() {
+    local gid="$1" fallback_name="$2" group
+    group="$(getent group "${gid}" | cut -d: -f1 || true)"
+    if [[ -z "${group}" ]]; then
+        groupadd --gid "${gid}" "${fallback_name}"
+        group="${fallback_name}"
+    fi
+    usermod --append --groups "${group}" arm
+}
+
+# Test seam: lets services/_common/test-entrypoint-render.sh source the
+# functions above without executing the entrypoint (mirrors install.sh's
+# ARM_INSTALL_SOURCE_ONLY). No-op in production.
+[[ -n "${ARM_ENTRYPOINT_SOURCE_ONLY:-}" ]] && return 0
+
 if [[ -f /etc/ssl/arm/arm-ca.crt ]]; then
     cp /etc/ssl/arm/arm-ca.crt /usr/local/share/ca-certificates/arm-ca.crt
     update-ca-certificates >/dev/null
@@ -30,19 +97,9 @@ if [[ -n "${CDROM_GID:-}" ]]; then
     usermod --append --groups "${cdrom_group}" arm
 fi
 
-# Transcode-only path: VAAPI/QSV transcoders get the host's /dev/dri render node
-# (root:render 0660) passed in by the dispatcher. The node is group-owned, so the
-# `arm` user must join that group IN /etc/group — `gosu` resets supplementary
-# groups to the user's membership, dropping any docker --group-add. Mirrors the
-# CDROM_GID handling above. No-op when RENDER_GID is unset (CPU / NVENC / ripper).
-if [[ -n "${RENDER_GID:-}" ]]; then
-    render_group="$(getent group "${RENDER_GID}" | cut -d: -f1 || true)"
-    if [[ -z "${render_group}" ]]; then
-        groupadd --gid "${RENDER_GID}" render-host
-        render_group="render-host"
-    fi
-    usermod --append --groups "${render_group}" arm
-fi
+# Transcode-only path: VAAPI/QSV render-node access (see setup_render_access
+# above — explicit RENDER_GID wins, else derived from the mounted nodes).
+setup_render_access
 
 # Backend-only path: when /var/run/docker.sock is bind-mounted in so the
 # transcode dispatcher can spawn arm-transcode-* containers, the socket's

--- a/services/_common/test-entrypoint-render.sh
+++ b/services/_common/test-entrypoint-render.sh
@@ -70,7 +70,7 @@ usermod() { USERMODS+=("${3}"); }          # called as: usermod --append --group
 run_fn() {  # run setup_render_access in THIS shell; capture output to files.
     # (Command substitution would subshell the call and lose the shadow
     # functions' array mutations — capture via redirection instead.)
-    setup_render_access >"$TMP/out" 2>"$TMP/err" || true
+    setup_render_access >"$TMP/out" 2>"$TMP/err"
 }
 out() { cat "$TMP/out" 2>/dev/null || true; }
 err() { cat "$TMP/err" 2>/dev/null || true; }
@@ -148,6 +148,18 @@ GETENT_KNOWN=(44)
 run_fn
 check "adopt: no groupadd" "0" "${#GROUPADDS[@]}"
 check "adopt: joined existing group" "grp44" "${USERMODS[0]:-}"
+
+# 11. Explicit RENDER_GID=0 -> refused (never add arm to gid 0), no join.
+reset_state
+RENDER_GID=0 run_fn
+check "explicit gid0: refused" "0" "${#USERMODS[@]}"
+check "explicit gid0: warning" "yes" "$( [[ "$(err)" == *"never adding arm to gid 0"* ]] && echo yes || echo no )"
+
+# 12. All nodes group-root + HW assigned -> accurate 'no usable gid' FAILED line.
+reset_state
+touch "$TMP/renderD128"; STAT_GIDS[renderD128]=0
+ARM_GPU_DEVICE=/dev/dri/renderD128 run_fn
+check "gid0+assigned: no-usable FAILED line" "yes" "$( [[ "$(err)" == *"no usable render gid"* ]] && echo yes || echo no )"
 
 # 10. Unstatable node -> FAILED line, continues (no crash under set -e).
 reset_state

--- a/services/_common/test-entrypoint-render.sh
+++ b/services/_common/test-entrypoint-render.sh
@@ -149,19 +149,19 @@ run_fn
 check "adopt: no groupadd" "0" "${#GROUPADDS[@]}"
 check "adopt: joined existing group" "grp44" "${USERMODS[0]:-}"
 
-# 11. Explicit RENDER_GID=0 -> refused (never add arm to gid 0), no join.
+# 10. Explicit RENDER_GID=0 -> refused (never add arm to gid 0), no join.
 reset_state
 RENDER_GID=0 run_fn
 check "explicit gid0: refused" "0" "${#USERMODS[@]}"
 check "explicit gid0: warning" "yes" "$( [[ "$(err)" == *"never adding arm to gid 0"* ]] && echo yes || echo no )"
 
-# 12. All nodes group-root + HW assigned -> accurate 'no usable gid' FAILED line.
+# 11. All nodes group-root + HW assigned -> accurate 'no usable gid' FAILED line.
 reset_state
 touch "$TMP/renderD128"; STAT_GIDS[renderD128]=0
 ARM_GPU_DEVICE=/dev/dri/renderD128 run_fn
 check "gid0+assigned: no-usable FAILED line" "yes" "$( [[ "$(err)" == *"no usable render gid"* ]] && echo yes || echo no )"
 
-# 10. Unstatable node -> FAILED line, continues (no crash under set -e).
+# 12. Unstatable node -> FAILED line, continues (no crash under set -e).
 reset_state
 touch "$TMP/renderD128"   # no STAT_GIDS entry -> shadow stat returns 1
 run_fn

--- a/services/_common/test-entrypoint-render.sh
+++ b/services/_common/test-entrypoint-render.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2317,SC2329
+# (The shadow functions below are invoked INDIRECTLY by the sourced
+# entrypoint, which newer shellcheck flags as unreachable/uninvoked —
+# the exact "ignore if invoked indirectly" case the warning describes.)
 # Plain-bash unit test for the entrypoint's render-node access setup.
 # No bats — the repo gates shell with shellcheck only. Runs with no Docker,
 # no root: it sources docker-entrypoint.sh (via ARM_ENTRYPOINT_SOURCE_ONLY)

--- a/services/_common/test-entrypoint-render.sh
+++ b/services/_common/test-entrypoint-render.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Plain-bash unit test for the entrypoint's render-node access setup.
+# No bats — the repo gates shell with shellcheck only. Runs with no Docker,
+# no root: it sources docker-entrypoint.sh (via ARM_ENTRYPOINT_SOURCE_ONLY)
+# and drives setup_render_access with shadowed groupadd/usermod/getent/stat.
+#
+# Covers the RENDER_GID fragility: derivation from mounted render nodes
+# (device nodes keep their HOST gid inside the container), explicit-override
+# precedence, the gid-0 refusal, and the no-node no-op.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENTRYPOINT="${HERE}/docker-entrypoint.sh"
+
+# Fail fast if the source-only seam is missing: sourcing without it would run
+# groupadd/usermod/exec on this machine.
+if ! grep -q 'ARM_ENTRYPOINT_SOURCE_ONLY' "$ENTRYPOINT"; then
+    echo "FAIL - docker-entrypoint.sh has no ARM_ENTRYPOINT_SOURCE_ONLY seam; refusing to source it" >&2
+    exit 1
+fi
+
+export ARM_ENTRYPOINT_SOURCE_ONLY=1
+# shellcheck disable=SC1090
+source "$ENTRYPOINT"
+
+fail=0
+check() {  # check <label> <expected> <actual>
+    local label="$1" want="$2" got="$3"
+    if [[ "$want" == "$got" ]]; then
+        echo "ok   - ${label}"
+    else
+        echo "FAIL - ${label}: expected '${want}', got '${got}'" >&2
+        fail=1
+    fi
+}
+
+# --- shadows: record group mutations instead of performing them --------------
+# Scripted gid per node basename, set by each test via STAT_GIDS.
+declare -A STAT_GIDS=()
+GROUPADDS=()   # "gid:name"
+USERMODS=()    # group names arm was appended to
+GETENT_KNOWN=() # gids that "exist" in the image; name is grp<gid>
+
+# shellcheck disable=SC2329
+stat() {  # only the entrypoint's `stat -c '%g' <path>` form is exercised
+    local path="${3:-${2:-}}"
+    local base; base="$(basename "$path")"
+    if [[ -n "${STAT_GIDS[$base]:-}" ]]; then
+        printf '%s\n' "${STAT_GIDS[$base]}"
+        return 0
+    fi
+    return 1
+}
+# shellcheck disable=SC2329
+getent() {  # `getent group <gid>` → "grp<gid>:x:<gid>:" when known
+    local gid="$2" g
+    for g in "${GETENT_KNOWN[@]}"; do
+        if [[ "$g" == "$gid" ]]; then
+            printf 'grp%s:x:%s:\n' "$gid" "$gid"
+            return 0
+        fi
+    done
+    return 2
+}
+# shellcheck disable=SC2329
+groupadd() { GROUPADDS+=("${2}:${3}"); }   # called as: groupadd --gid <gid> <name>
+# shellcheck disable=SC2329
+usermod() { USERMODS+=("${3}"); }          # called as: usermod --append --groups <name> arm
+
+run_fn() {  # run setup_render_access in THIS shell; capture output to files.
+    # (Command substitution would subshell the call and lose the shadow
+    # functions' array mutations — capture via redirection instead.)
+    setup_render_access >"$TMP/out" 2>"$TMP/err" || true
+}
+out() { cat "$TMP/out" 2>/dev/null || true; }
+err() { cat "$TMP/err" 2>/dev/null || true; }
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+_case=0
+reset_state() {
+    STAT_GIDS=(); GROUPADDS=(); USERMODS=(); GETENT_KNOWN=()
+    unset RENDER_GID ARM_GPU_DEVICE 2>/dev/null || true
+    _case=$((_case + 1))
+    TMP="$TMPROOT/case-$_case"
+    mkdir -p "$TMP"
+    export ARM_RENDER_NODE_DIR="$TMP"
+}
+
+# 1. Explicit RENDER_GID wins; derivation is skipped entirely.
+reset_state
+touch "$TMP/renderD128"; STAT_GIDS[renderD128]=555   # would derive 555 if consulted
+RENDER_GID=993 run_fn
+check "explicit: log line" "yes" "$( [[ "$(out)" == *"render access: RENDER_GID=993 (explicit)"* ]] && echo yes || echo no )"
+check "explicit: creates legacy render-host name" "993:render-host" "${GROUPADDS[0]:-}"
+check "explicit: arm joined" "render-host" "${USERMODS[0]:-}"
+check "explicit: derivation skipped" "1" "${#USERMODS[@]}"
+
+# 2. Derivation: single node -> its gid joined, log line names it.
+reset_state
+touch "$TMP/renderD128"; STAT_GIDS[renderD128]=993
+run_fn
+check "derive: groupadd render-host-<gid>" "993:render-host-993" "${GROUPADDS[0]:-}"
+check "derive: arm joined" "render-host-993" "${USERMODS[0]:-}"
+check "derive: log line" "yes" "$( [[ "$(out)" == *"render access: derived gid(s) 993"* ]] && echo yes || echo no )"
+
+# 3. Derivation: two nodes, two distinct gids -> both joined once each.
+reset_state
+touch "$TMP/renderD128" "$TMP/renderD129"
+STAT_GIDS[renderD128]=993; STAT_GIDS[renderD129]=44
+run_fn
+check "two gids: both joined" "2" "${#USERMODS[@]}"
+
+# 4. Derivation: two nodes, SAME gid -> joined once (dedup).
+reset_state
+touch "$TMP/renderD128" "$TMP/renderD129"
+STAT_GIDS[renderD128]=993; STAT_GIDS[renderD129]=993
+run_fn
+check "dup gid: joined once" "1" "${#USERMODS[@]}"
+
+# 5. gid 0 -> refused with warning, arm NOT added to root group.
+reset_state
+touch "$TMP/renderD128"; STAT_GIDS[renderD128]=0
+run_fn
+check "gid0: refused" "0" "${#USERMODS[@]}"
+check "gid0: warning" "yes" "$( [[ "$(err)" == *"refusing to add arm to gid 0"* ]] && echo yes || echo no )"
+
+# 6. No nodes, no ARM_GPU_DEVICE -> silent no-op (backend/ripper/ui/CPU path).
+reset_state
+run_fn
+check "no nodes: no-op" "0" "${#USERMODS[@]}"
+check "no nodes: silent" "" "$(out)$(err)"
+
+# 7. No nodes but a render-node ARM_GPU_DEVICE assigned -> distinct FAILED line.
+reset_state
+ARM_GPU_DEVICE=/dev/dri/renderD128 run_fn
+check "assigned-but-missing: FAILED line" "yes" "$( [[ "$(err)" == *"render access: FAILED"* ]] && echo yes || echo no )"
+
+# 8. NVENC assignment (nvidia:// device) with no /dev/dri -> still silent.
+reset_state
+ARM_GPU_DEVICE="nvidia://0" run_fn
+check "nvenc: silent no-op" "" "$(out)$(err)"
+
+# 9. Derived gid already exists as an image group -> adopted, no groupadd.
+reset_state
+touch "$TMP/renderD128"; STAT_GIDS[renderD128]=44
+GETENT_KNOWN=(44)
+run_fn
+check "adopt: no groupadd" "0" "${#GROUPADDS[@]}"
+check "adopt: joined existing group" "grp44" "${USERMODS[0]:-}"
+
+# 10. Unstatable node -> FAILED line, continues (no crash under set -e).
+reset_state
+touch "$TMP/renderD128"   # no STAT_GIDS entry -> shadow stat returns 1
+run_fn
+check "unstatable: FAILED line" "yes" "$( [[ "$(err)" == *"render access: FAILED"* ]] && echo yes || echo no )"
+check "unstatable: no join" "0" "${#USERMODS[@]}"
+
+exit "$fail"

--- a/services/backend/arm_backend/config.py
+++ b/services/backend/arm_backend/config.py
@@ -95,11 +95,11 @@ class Settings(BaseSettings):
     # for the schema. Re-run the installer after a GPU/driver change.
     ARM_GPUS: str = ""
 
-    # GID of the host's /dev/dri render node group (detected host-side, like
-    # CDROM_GID for the ripper). The dispatcher adds it via `group_add` to each
-    # VAAPI/QSV transcoder so the PUID-dropped process can open the render node
-    # (root:render 0660) — without it HandBrake's QSV/VAAPI init fails with
-    # "failed to create hwdevice". Empty => no group added (CPU / NVENC-only).
+    # OPTIONAL override for the render-node group gid handed to QSV/VAAPI
+    # transcode containers. Normally UNSET: the container entrypoint derives
+    # the gid from the mounted /dev/dri/renderD* node itself (device nodes
+    # keep their host gid), which is correct on local and remote offload
+    # hosts alike. Set only to force a specific gid (exotic device perms).
     ARM_RENDER_GID: str = ""
 
 

--- a/services/backend/arm_backend/transcode_dispatcher.py
+++ b/services/backend/arm_backend/transcode_dispatcher.py
@@ -384,10 +384,9 @@ class TranscodeDispatcher:
             env["ARM_GPU_DEVICE"] = assignment.gpu.device_path
             if assignment.codec is not None:
                 env["ARM_GPU_CODEC"] = assignment.codec
-            # VAAPI/QSV need the render-node group inside the container; the
-            # entrypoint adds `arm` to RENDER_GID before gosu (a docker
-            # --group-add wouldn't survive the gosu group reset). NVENC's device
-            # access comes via the nvidia runtime, so it doesn't need this.
+            # VAAPI/QSV: the entrypoint self-derives the render gid from the
+            # mounted node; an explicit ARM_RENDER_GID is a forced OVERRIDE
+            # (passed through as RENDER_GID, which wins in the entrypoint).
             if assignment.gpu.vendor in (GpuVendor.VAAPI, GpuVendor.QSV) and self._settings.ARM_RENDER_GID:
                 env["RENDER_GID"] = self._settings.ARM_RENDER_GID
             self._inject_gpu_run_kwargs(extra_run_kwargs, assignment.gpu)

--- a/services/backend/tests/test_transcode_dispatcher_gpu.py
+++ b/services/backend/tests/test_transcode_dispatcher_gpu.py
@@ -199,7 +199,8 @@ async def test_vaapi_available_claims_gpu_and_injects_devices() -> None:
     assert kwargs["environment"]["ARM_GPU_CODEC"] == "h265"
     assert kwargs["environment"]["ARM_GPU_DEVICE"] == "/dev/dri/renderD128"
     assert kwargs["devices"] == ["/dev/dri/renderD128:/dev/dri/renderD128:rwm"]
-    # No render GID configured → no RENDER_GID handed to the container entrypoint.
+    # No render GID configured → no RENDER_GID env; the entrypoint derives the
+    # gid from the mounted render node itself (derivation is the default).
     assert "RENDER_GID" not in kwargs["environment"]
     # GPU is claimed.
     assert db.rows["gpus"][0].status == GpuStatus.BUSY
@@ -220,9 +221,9 @@ async def test_qsv_available_uses_devices_injection() -> None:
 
 
 async def test_render_gid_passed_as_env_for_qsv() -> None:
-    """With ARM_RENDER_GID set, VAAPI/QSV spawns get RENDER_GID in the env so the
-    entrypoint adds `arm` to the render group (gosu would drop a docker
-    --group-add), letting the PUID transcoder open the /dev/dri node."""
+    """With ARM_RENDER_GID set, VAAPI/QSV spawns get RENDER_GID in the env as a
+    forced override — the entrypoint honors it over its own derivation from
+    the mounted node."""
     db = _build_db(
         hw_preference=HwPreference.ANY,
         gpus=[(GpuVendor.QSV, GpuStatus.AVAILABLE, ["h264", "h265"], None)],


### PR DESCRIPTION
QSV/VAAPI hardware encode currently depends on ARM_RENDER_GID being set and
correct — an unset or stale value silently degrades HW-intended transcodes to
CPU or rc=3 (this bit three times: the install probe's {} bug, the
probe-encoders drill reporting NVENC-only, and a hand-set gid on the hifi
test deploy). The gid is a host fact, not policy: device nodes keep their
HOST gid inside the container, so the entrypoint now stats the mounted
/dev/dri/renderD* nodes and joins arm to each distinct gid before the gosu
drop. An explicit RENDER_GID env still wins (back-compat + escape hatch);
gid 0 is refused on BOTH paths; every HW-relevant outcome logs a greppable
"render access:" line. Also covers remote transcode offload hosts, whose
render gid can differ from the local .env, with zero configuration.

New plain-bash suite (services/_common/test-entrypoint-render.sh, 22 checks)
sources the entrypoint via an ARM_ENTRYPOINT_SOURCE_ONLY seam (leak-proof:
sourced-ness checked); a test-shell CI job runs it. Dispatcher/config
changes are comments only — the existing ARM_RENDER_GID injection is now
documented as the override path.

No OpenAPI change. Note for #49: it adds a same-shaped test-shell CI job;
whichever lands second unions the two run steps.

Will be live-verified on the hifi deployment (QSV, both override and
derivation paths + remote NVENC regression) before we consider it done —
results will be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)